### PR TITLE
Chore/GCI-1279: Update commit hash for ch-sdk-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "ch-node-session-handler": "git+ssh://git@github.com/companieshouse/node-session-handler.git#3.0.1",
-    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#5707a0ba5156a91cd9a5a46ef991afaf5cd3aaee",
+    "ch-sdk-node": "git+ssh://git@github.com/companieshouse/ch-sdk-node.git#0097a5f5bfa8080ca35159096045f38a7d860dd8",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",
     "express": "4.17.1",


### PR DESCRIPTION
Change `package.json` to link to most recent commit hash for ch-sdk-node.