### PR TITLE
Add itemtype param to order confirmation page

### DIFF
--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -19,11 +19,25 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
         const orderId = req.params.orderId;
         const status = req.query.status;
         const ref = req.query.ref;
+        const itemType = req.query.itemType;
         const signInInfo = req.session?.data[SessionKey.SignInInfo];
         const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
         const userId = signInInfo?.[SignInInfoKeys.UserProfile]?.[UserProfileKeys.UserId];
 
-        logger.info(`Order confirmation, order_id=${orderId}, ref=${ref}, status=${status}, user_id=${userId}`);
+        if (itemType === undefined || itemType === "") {
+            const basket = await getBasket(accessToken);
+            const item = basket?.items?.[0];
+
+            if (item?.kind === "item#certificate") {
+                return res.redirect(req.originalUrl + "&itemType=certificate");
+            }
+
+            if (item?.kind === "item#certified-copy") {
+                return res.redirect(req.originalUrl + "&itemType=certified-copy");
+            }
+        }
+
+        logger.info(`Order confirmation, order_id=${orderId}, ref=${ref}, status=${status}, itemType=${itemType}, user_id=${userId}`);
         if (status === "cancelled" || status === "failed") {
             const basket = await getBasket(accessToken);
             const item = basket?.items?.[0];

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -200,7 +200,7 @@ describe("order.confirmation.controller.integration", () => {
         getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertificateOrderResponse));
 
         chai.request(testApp)
-            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
             .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
             .end((err, resp) => {
                 if (err) return done(err);
@@ -228,7 +228,7 @@ describe("order.confirmation.controller.integration", () => {
         getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertifiedCopyOrderResponse));
 
         const resp = await chai.request(testApp)
-            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certified-copy`)
             .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
 
         const $ = cheerio.load(resp.text);
@@ -293,7 +293,7 @@ describe("order.confirmation.controller.integration", () => {
         it("redirects to " + itemKind.name + " check details page if status is cancelled and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
             const resp = await chai.request(testApp)
-                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled`)
+                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=certified-copy`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
                 .redirects(0);
             chai.expect(resp.text).to.include(`${itemKind.url}/check-details`);
@@ -302,7 +302,7 @@ describe("order.confirmation.controller.integration", () => {
         it("redirects to " + itemKind.name + " check details page if status is failed and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
             const resp = await chai.request(testApp)
-                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed`)
+                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=certified-copy`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
                 .redirects(0);
             chai.expect(resp.text).to.include(`${itemKind.url}/check-details`);

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -307,5 +307,14 @@ describe("order.confirmation.controller.integration", () => {
                 .redirects(0);
             chai.expect(resp.text).to.include(`${itemKind.url}/check-details`);
         });
+
+        it("redirects and applies the itemType query param", async () => {
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
+            const resp = await chai.request(testApp)
+                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+                .redirects(0);
+            chai.expect(resp).to.redirectTo(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=${itemKind.name}`);
+        });
     });
 });


### PR DESCRIPTION
Add a url parameter to allow piwik users to identify what item has been ordered.

Resolves: GCI-1381