### PR TITLE
change url for dissolved certificates

### DIFF
--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -28,12 +28,18 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
         if (status === "cancelled" || status === "failed") {
             const basket = await getBasket(accessToken);
             const item = basket?.items?.[0];
-            if (item?.kind === "item#certificate" || item?.kind === "item#certified-copy" || item?.kind === "item#missing-image-delivery") {
-                const redirectUrl = item?.itemUri + "/check-details";
-                logger.info(`Redirecting to ${redirectUrl}`);
-                return res.redirect(redirectUrl);
+            const order: Order = await getOrder(accessToken, orderId);
+            const itemOrder = order?.items?.[0];
+            const itemOrderOptions = itemOrder.itemOptions as CertificateItemOptions;
+            let redirectUrl;
+            if ((item?.kind === "item#certificate" && itemOrderOptions?.certificateType !== "dissolution") || item?.kind === "item#certified-copy" || item?.kind === "item#missing-image-delivery") {
+                redirectUrl = item?.itemUri + "/check-details";
+            } else {
+                redirectUrl = `/orderable/dissolved-certificates/${item?.id}/check-details`;
             }
-        }
+            logger.info(`Redirecting to ${redirectUrl}`);
+            return res.redirect(redirectUrl);
+        };
 
         const order: Order = await getOrder(accessToken, orderId);
         if (itemType === undefined || itemType === "") {

--- a/src/service/map.item.service.ts
+++ b/src/service/map.item.service.ts
@@ -25,7 +25,6 @@ export const mapItem = (item: Item, deliveryDetails: DeliveryDetails| undefined)
 
         const itemOptionsCertificate = item.itemOptions as CertificateItemOptions;
         const certificateType = itemOptionsCertificate.certificateType;
-
         if (certificateType === "incorporation-with-all-name-changes") {
             const certificateDetails = {
                 certificateType: mapCertificateType(itemOptionsCertificate.certificateType),
@@ -151,7 +150,7 @@ export const mapItem = (item: Item, deliveryDetails: DeliveryDetails| undefined)
                 }
             ];
             return {
-                serviceUrl: `/company/${item?.companyNumber}/orderable/certificates`,
+                serviceUrl: `/company/${item?.companyNumber}/orderable/dissolved-certificates`,
                 serviceName: SERVICE_NAME_CERTIFICATES,
                 titleText: "Certificate ordered",
                 pageTitle: "Certificate ordered confirmation",

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -205,6 +205,7 @@ describe("order.confirmation.controller.integration", () => {
 
         it("redirects to " + itemKind.name + " check details page if status is cancelled and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
+            getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertificateOrderResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=${itemKind.name}`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
@@ -214,11 +215,54 @@ describe("order.confirmation.controller.integration", () => {
 
         it("redirects to " + itemKind.name + " check details page if status is failed and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
+            getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertificateOrderResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=${itemKind.name}`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
                 .redirects(0);
             chai.expect(resp.text).to.include(`${itemKind.url}/check-details`);
         });
+    });
+
+    const dissolvedCertificatebasketCancelledFailedResponse = {
+        deliveryDetails: {
+            addressLine1: "117 kings road",
+            addressLine2: "canton",
+            country: "wales",
+            forename: "John",
+            locality: "Cardiff",
+            poBox: "po box",
+            postalCode: "CF5 3NB",
+            region: "Glamorgan",
+            surname: "Smith"
+        },
+        etag: "etag",
+        items: [{
+            itemOptions: { key: {} },
+            itemUri: "/orderable/certificates/CRT-123456-123456",
+            kind: "item#certificate",
+            links: { self: "item#certificate" },
+            itemId: "CRT-123456-123456"
+        }]
+    } as unknown as Basket;
+
+    it("redirects to dissolved certificates check details page if status is cancelled", async () => {
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
+        getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockDissolvedCertificateOrderResponse));
+        const resp = await chai.request(testApp)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=dissolved-certificate`)
+            .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+            .redirects(0);
+        chai.expect(resp.text).to.include(`/orderable/dissolved-certificates/${dissolvedCertificatebasketCancelledFailedResponse.items?.[0].id}/check-details`);
+    });
+
+    it("redirects to dissolved certificates check details page if status is failed", async () => {
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
+        getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockDissolvedCertificateOrderResponse));
+        const resp = await chai.request(testApp)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=dissolved-certificate`)
+            .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+            .redirects(0);
+        chai.expect(resp.text).to.include(`/orderable/dissolved-certificates/${dissolvedCertificatebasketCancelledFailedResponse.items?.[0].id}/check-details`);
     });
 });

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -196,7 +196,7 @@ describe("order.confirmation.controller.integration", () => {
             },
             etag: "etag",
             items: [{
-                itemOptions: { key: {} },
+                itemOptions: { certificateType: "incorporation-with-all-name-changes" },
                 itemUri: itemKind.url,
                 kind: itemKind.kind,
                 links: { self: itemKind.url }
@@ -205,7 +205,6 @@ describe("order.confirmation.controller.integration", () => {
 
         it("redirects to " + itemKind.name + " check details page if status is cancelled and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
-            getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertificateOrderResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=${itemKind.name}`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
@@ -215,7 +214,6 @@ describe("order.confirmation.controller.integration", () => {
 
         it("redirects to " + itemKind.name + " check details page if status is failed and item type is " + itemKind.name, async () => {
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
-            getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockCertificateOrderResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=${itemKind.name}`)
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
@@ -238,7 +236,9 @@ describe("order.confirmation.controller.integration", () => {
         },
         etag: "etag",
         items: [{
-            itemOptions: { key: {} },
+            itemOptions: {
+                certificateType: "dissolution"
+            },
             itemUri: "/orderable/certificates/CRT-123456-123456",
             kind: "item#certificate",
             links: { self: "item#certificate" },
@@ -248,7 +248,6 @@ describe("order.confirmation.controller.integration", () => {
 
     it("redirects to dissolved certificates check details page if status is cancelled", async () => {
         getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
-        getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockDissolvedCertificateOrderResponse));
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=dissolved-certificate`)
             .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
@@ -258,7 +257,6 @@ describe("order.confirmation.controller.integration", () => {
 
     it("redirects to dissolved certificates check details page if status is failed", async () => {
         getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
-        getOrderStub = sandbox.stub(apiClient, "getOrder").returns(Promise.resolve(mockDissolvedCertificateOrderResponse));
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=dissolved-certificate`)
             .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])

--- a/src/test/controllers/order.confirmation.controller.unit.test.ts
+++ b/src/test/controllers/order.confirmation.controller.unit.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 
 import { getItemTypeUrlParam } from "../../controllers/order.confirmation.controller";
-import { mockCertificateItem, mockCertifiedCopyItem, mockMissingImageDeliveryItem } from "../__mocks__/order.mocks";
+import { mockCertificateItem, mockCertifiedCopyItem, mockMissingImageDeliveryItem, mockDissolvedCertificateItem } from "../__mocks__/order.mocks";
 
 describe("order.confirmation.controller.unit", () => {
     describe("getItemTypeUrlParam", () => {
@@ -11,20 +11,7 @@ describe("order.confirmation.controller.unit", () => {
         });
 
         it("get itemType for dissolved certificate correctly", () => {
-            const mockDissolved = mockCertificateItem;
-            mockDissolved.itemOptions = {
-                certificateType: "dissolved",
-                deliveryMethod: "postal",
-                deliveryTimescale: "standard",
-                directorDetails: {},
-                forename: "forename",
-                includeGoodStandingInformation: true,
-                registeredOfficeAddressDetails: {},
-                secretaryDetails: {},
-                surname: "surname"
-            };
-
-            const result = getItemTypeUrlParam(mockDissolved);
+            const result = getItemTypeUrlParam(mockDissolvedCertificateItem);
             chai.expect(result).to.equal("&itemType=dissolved-certificate");
         });
 

--- a/src/test/controllers/order.confirmation.controller.unit.test.ts
+++ b/src/test/controllers/order.confirmation.controller.unit.test.ts
@@ -11,9 +11,8 @@ describe("order.confirmation.controller.unit", () => {
         });
 
         it("get itemType for dissolved certificate correctly", () => {
-
             const mockDissolved = mockCertificateItem;
-            mockDissolved.itemOptions =  {
+            mockDissolved.itemOptions = {
                 certificateType: "dissolved",
                 deliveryMethod: "postal",
                 deliveryTimescale: "standard",
@@ -23,7 +22,7 @@ describe("order.confirmation.controller.unit", () => {
                 registeredOfficeAddressDetails: {},
                 secretaryDetails: {},
                 surname: "surname"
-            }
+            };
 
             const result = getItemTypeUrlParam(mockDissolved);
             chai.expect(result).to.equal("&itemType=dissolved-certificate");

--- a/src/test/service/map.item.service.unit.test.ts
+++ b/src/test/service/map.item.service.unit.test.ts
@@ -34,7 +34,7 @@ describe("map.item.service.unit", () => {
 
         it("should return correct data if item is certificate of type dissolved", () => {
             const result = mapItem(mockDissolvedCertificateItem, deliveryDetails);
-            expect(result.serviceUrl).to.equal(`/company/${mockCertificateItem?.companyNumber}/orderable/certificates`);
+            expect(result.serviceUrl).to.equal(`/company/${mockDissolvedCertificateItem?.companyNumber}/orderable/dissolved-certificates`);
             expect(result.serviceName).to.equal("Order a certificate");
             expect(result.titleText).to.equal("Certificate ordered");
             expect(result.pageTitle).to.equal("Certificate ordered confirmation");


### PR DESCRIPTION
Updated logic to allow user to return to dissolved certs check details page when a payment is cancelled.
Updated service url on confirmation page to return to dissolved certificates start now page