### PR TITLE
BI-8777 Remove notification email warning from template

### DIFF
--- a/src/views/order-complete.html
+++ b/src/views/order-complete.html
@@ -22,8 +22,7 @@
       <p class="govuk-body">{{ happensNext | safe}}</p>
       {% if piwikLink === "certificates" %}
         {{ govukInsetText({
-          html: "<p class='govuk-body govuk-!-font-weight-bold'>You will not be sent an email confirmation of this order.</p> 
-          <ul class='govuk-list'>
+          html: "<ul class='govuk-list'>
             <li id='print-page-link'>
               <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/> 
                 <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-certificates'>
@@ -35,8 +34,7 @@
       {% endif %}
       {% if piwikLink === "certified-copies" %}
       {{ govukInsetText({
-        html: "<p class='govuk-body govuk-!-font-weight-bold'>You will not be sent an email confirmation of this order.</p> 
-        <ul class='govuk-list'>
+        html: "<ul class='govuk-list'>
           <li id='print-page-link'>
             <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/> 
               <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-certified-copies'>
@@ -48,8 +46,7 @@
       {% endif %}
       {% if piwikLink === "" %}
       {{ govukInsetText({
-        html: "<p class='govuk-body govuk-!-font-weight-bold'>You will not be sent an email confirmation of this order.</p> 
-        <ul class='govuk-list'>
+        html: "<ul class='govuk-list'>
           <li id='print-page-link'>
             <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/> 
               <a class='govuk-link' href='javascript:window.print()' >


### PR DESCRIPTION
* Remove warning from confirmation template that user will not receive
a confirmation email as this has now been implemented via new
order-notification-sender service.

Resolves:
[BI-8777](https://companieshouse.atlassian.net/browse/BI-8777)