### PR TITLE
update to gov uk branding

### DIFF
--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -24,6 +24,9 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
         const signInInfo = req.session?.data[SessionKey.SignInInfo];
         const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
         const userId = signInInfo?.[SignInInfoKeys.UserProfile]?.[UserProfileKeys.UserId];
+        const CERTIFICATE_PAGE_TITLE = "Certificate ordered- Order a certificate - GOV.UK";
+        const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document- GOV.UK";
+        const MID_PAGE_TITLE = "Document Requested - Request a document - GOV.UK";
 
         logger.info(`Order confirmation, order_id=${orderId}, ref=${ref}, status=${status}, itemType=${itemType}, user_id=${userId}`);
         if (status === "cancelled" || status === "failed") {
@@ -62,6 +65,9 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
 
         const mappedItem = mapItem(item, order?.deliveryDetails);
 
+        const pageTitle = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
+            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
+
         res.render(ORDER_COMPLETE, {
             ...mappedItem,
             companyNumber: item?.companyNumber,
@@ -69,7 +75,8 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
             paymentDetails,
             itemKind,
             totalItemsCost,
-            templateName: ORDER_COMPLETE
+            templateName: ORDER_COMPLETE,
+            pageTitleText: pageTitle
         });
     } catch (err) {
         console.log(err);

--- a/src/views/components/footer/template.njk
+++ b/src/views/components/footer/template.njk
@@ -50,8 +50,16 @@
             </div>
           {% endif %}
         {% endif %}
+        <span class="govuk-footer__inline-list-item">
+            Built by <a class="govuk-footer__link" href="https://find-and-update.company-information.service.gov.uk/" rel="license">Companies House</a>
+        </span>
       </div>
-
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
     </div>
   </div>
-</footer> 
+</footer>

--- a/src/views/error-not-found.html
+++ b/src/views/error-not-found.html
@@ -3,15 +3,13 @@
 
 {% block header %}
 {% include "includes/cookie-banner.html" %}
-  {{ chHeader({
-    homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    assetPath: ""
+  {{ govukHeader({
+    homepageUrl: "http://gov.uk/"
   }) }}
 {% endblock %}
 
 {% block pageTitle %}
-  Page not found - GOV.UK
+  Page not found - Request a document - GOV.UK
 {% endblock %}
 
 {% block content %}

--- a/src/views/error-start-again.html
+++ b/src/views/error-start-again.html
@@ -1,14 +1,12 @@
 {% extends "layout.html" %} 
 {% block header %}
 {% include "includes/cookie-banner.html" %}
-  {{ chHeader({
-    homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    assetPath: ""
+  {{ govukHeader({
+    homepageUrl: "http://gov.uk/"
   }) }}
 {% endblock %}
 
-{% block pageTitle %} Page not found {% endblock %}
+{% block pageTitle %} Page not found - Request a document - GOV.UK {% endblock %}
 
 {% set mainClasses = "govuk-main-wrapper--l" %}
 

--- a/src/views/error.html
+++ b/src/views/error.html
@@ -3,15 +3,13 @@
 
 {% block header %}
 {% include "includes/cookie-banner.html" %}
-  {{ chHeader({
-    homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    assetPath: ""
+ {{ govukHeader({
+    homepageUrl: "http://gov.uk/"
   }) }}
 {% endblock %}
 
 {% block pageTitle %}
-  Sorry, there is a problem with the service - GOV.UK
+  Sorry, there is a problem with the service - Request a document - GOV.UK
 {% endblock %}
 
 {% block content %}

--- a/src/views/layout.html
+++ b/src/views/layout.html
@@ -1,7 +1,7 @@
 {% extends "components/template.njk" %}
 
 {% from "./components/footer/macro.njk"               import chFooter %}
-{% from "./components/header/macro.njk"               import chHeader %}
+{% from "govuk/components/header/macro.njk"           import govukHeader %}
 {% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
 {% from "govuk/components/panel/macro.njk"            import govukPanel %}
 {% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
@@ -14,8 +14,8 @@
 <link rel="stylesheet" type="text/css" media="all" href="{{ CSS_URL }}" />
 <link rel="stylesheet" type="text/css" media="all" href="{{ FOOTER }}" />
 <!--<![endif]-->
-<link rel="SHORTCUT ICON" href="//{{CDN_URL}}/images/favicon.ico" />
-<link rel="icon" href="//{{CDN_URL}}/images/favicon.ico" type="image/x-icon" />
+<link rel="SHORTCUT ICON" href="//{{CDN_URL}}/images/govuk-frontend/v3.5.0/images/favicon.ico" />
+<link rel="icon" href="//{{CDN_URL}}/images/govuk-frontend/v3.5.0/images/favicon.ico" type="image/x-icon" />
 
 <script src="https://code.jquery.com/jquery-1.12.4.min.js"
           integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
@@ -38,12 +38,10 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {{ chHeader({
-    homepageUrl: "/",
+  {{ govukHeader({
+    homepageUrl: "http://gov.uk/",
     serviceName: serviceName,
-    serviceUrl: serviceUrl,
-    containerClasses: "govuk-width-container",
-    assetPath: ""
+    serviceUrl: serviceUrl
   }) }}
 {% endblock %}
 
@@ -63,6 +61,10 @@
           {
             href: "https://beta.companieshouse.gov.uk/help/contact-us",
             text: "Contact us"
+          },
+          {
+            href: "/help/accessibility-statement",
+            text: "Accessibility statement"
           },
           {
             href: "https://developer.companieshouse.gov.uk/api/docs/",

--- a/src/views/order-complete.html
+++ b/src/views/order-complete.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  {{ pageTitle }}
+  {{ pageTitleText }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/static/footer.scss
+++ b/static/footer.scss
@@ -21,7 +21,6 @@ html, body {
 
 #footer {
   border-top: 10px solid #005ea5;
-  height: 60px;
 }
 
 .push {


### PR DESCRIPTION
update favicon to govuk crown
update header to to use govuk header
update page titles to match govuk composition
add accessibility link to footer
update footer to show crown copyright
update footer to include Built by companies house with link to ch site
remove css style on footer which was causing alignment issues

Resolves: CHS-2047 CHS-2041 CHS-2037 CHS-2054 BI-8759 BI-8760 BI-8758