### PR TITLE
BI-9119 Fix order page confirmation bug when address details option not selected

### DIFF
--- a/src/service/LLPCertificateItemMapper.ts
+++ b/src/service/LLPCertificateItemMapper.ts
@@ -96,7 +96,7 @@ export class LLPCertificateItemMapper extends ItemMapper {
     }
 
     mapRegisteredOfficeAddress = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions.registeredOfficeAddressDetails);
+        return MapUtil.mapAddressOptions(itemOptions?.registeredOfficeAddressDetails);
     }
 
     mapDesignatedMembersOptions = (designatedMembersOptions?: DesignatedMemberDetails): string => {

--- a/src/service/LPCertificateItemMapper.ts
+++ b/src/service/LPCertificateItemMapper.ts
@@ -109,6 +109,6 @@ export class LPCertificateItemMapper extends ItemMapper {
     }
 
     mapPrincipalPlaceOfBusiness = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions.principalPlaceOfBusinessDetails);
+        return MapUtil.mapAddressOptions(itemOptions?.principalPlaceOfBusinessDetails);
     }
 }

--- a/src/service/MapUtil.ts
+++ b/src/service/MapUtil.ts
@@ -79,8 +79,11 @@ export abstract class MapUtil {
         return cleanedCertificateType.charAt(0).toUpperCase() + cleanedCertificateType.slice(1);
     }
 
-    static mapAddressOptions = (addressDetais: { includeAddressRecordsType?: string }): string => {
-        switch (addressDetais.includeAddressRecordsType) {
+    static mapAddressOptions = (addressDetails: { includeAddressRecordsType?: string } | undefined): string => {
+        if (addressDetails === undefined || addressDetails.includeAddressRecordsType === undefined) {
+            return "No";
+        }
+        switch (addressDetails.includeAddressRecordsType) {
             case AddressRecordsType.CURRENT:
                 return "Current address";
 
@@ -93,11 +96,8 @@ export abstract class MapUtil {
             case AddressRecordsType.ALL:
                 return "All current and previous addresses";
 
-            case undefined:
-                return "No";
-
             default:
-                logger.error(`Unable to map value for registered office address options: ${addressDetais.includeAddressRecordsType}`);
+                logger.error(`Unable to map value for registered office address options: ${addressDetails.includeAddressRecordsType}`);
                 return "";
         }
     }

--- a/src/service/OtherCertificateItemMapper.ts
+++ b/src/service/OtherCertificateItemMapper.ts
@@ -91,7 +91,7 @@ export class OtherCertificateItemMapper extends ItemMapper {
     }
 
     mapRegisteredOfficeAddress = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions.registeredOfficeAddressDetails);
+        return MapUtil.mapAddressOptions(itemOptions?.registeredOfficeAddressDetails);
     }
 
     determineDirectorOrSecretaryOptionsText = (directorOrSecretaryDetails: DirectorOrSecretaryDetails, officer: string) => {

--- a/src/test/service/MapUtil.unit.test.ts
+++ b/src/test/service/MapUtil.unit.test.ts
@@ -2,6 +2,7 @@ import {MapUtil} from "../../service/MapUtil";
 import {expect} from "chai";
 import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
 import { DISPATCH_DAYS } from "../../config/config";
+import {AddressRecordsType} from "../../model/AddressRecordsType";
 
 describe("MapUtil unit tests", () => {
     describe("determineItemOptionsSelectedText", () => {
@@ -91,6 +92,43 @@ describe("MapUtil unit tests", () => {
         it("maps same-day to Same Day", () => {
             const result = MapUtil.mapDeliveryMethod({deliveryTimescale: "same-day"} as CertificateItemOptions);
             expect(result).to.equal("Same Day");
+        });
+    });
+
+    describe("addressMapping unit tests", () => {
+        it("correctly handles the case where registeredOfficeAddressDetails are undefined", () => {
+            const result = MapUtil.mapAddressOptions(undefined);
+            expect(result).to.equal("No");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType is undefined", () => {
+            const result = MapUtil.mapAddressOptions({});
+            expect(result).to.equal("No");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType is defined but set to undefine", () => {
+            const result = MapUtil.mapAddressOptions({includeAddressRecordsType: undefined});
+            expect(result).to.equal("No");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType current", () => {
+            const result = MapUtil.mapAddressOptions({includeAddressRecordsType: AddressRecordsType.CURRENT});
+            expect(result).to.equal("Current address");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType current and previous", () => {
+            const result = MapUtil.mapAddressOptions({includeAddressRecordsType: AddressRecordsType.CURRENT_AND_PREVIOUS});
+            expect(result).to.equal("Current address and the one previous");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType current previous and prior", () => {
+            const result = MapUtil.mapAddressOptions({includeAddressRecordsType: AddressRecordsType.CURRENT_PREVIOUS_AND_PRIOR});
+            expect(result).to.equal("Current address and the two previous");
+        });
+
+        it("correctly handles the case where registeredOfficeAddressDetails is defined but includeAddressRecordsType ALL", () => {
+            const result = MapUtil.mapAddressOptions({includeAddressRecordsType: AddressRecordsType.ALL});
+            expect(result).to.equal("All current and previous addresses");
         });
     });
 });


### PR DESCRIPTION
* Ensure that address details are mapped correctly when they are undefined

Resolves: [BI-9119: TypeError thrown on confirmation page](https://companieshouse.atlassian.net/browse/BI-9119)