### PR TITLE
BI-6863 - Update order confirmation page to use checkout to prevent race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.63.tgz",
-      "integrity": "sha512-VLkynF9KYsA9UqDtptP3QnuJqx2TCb2zTIRGt8nEY9SMalJxoyh/+PY1IbneuCJQJf2zoDVbTLh3hdD+gLWwBQ==",
+      "version": "1.0.66",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.66.tgz",
+      "integrity": "sha512-DjAJ8R6fJmw7aE20vfpyZCqPsUk2rH5ZltNf1L2aoXU145KsOve6SVTnx+sY5zWuMm1Lb2XtAjMV+NI82XLAmA==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.63",
+    "@companieshouse/api-sdk-node": "^1.0.66",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from "@companieshouse/api-sdk-node";
-import { Checkout, Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket";
-import { Order } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { Checkout as BasketCheckout, Basket, CheckoutResource } from "@companieshouse/api-sdk-node/dist/services/order/basket";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import { CreatePaymentRequest, Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
 import Resource, { ApiResponse, ApiResult } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { createLogger } from "ch-structured-logging";
@@ -22,9 +22,9 @@ export const getBasket = async (oAuth: string): Promise<Basket> => {
     return basketResource.resource as Basket;
 };
 
-export const checkoutBasket = async (oAuth: string): Promise<ApiResponse<Checkout>> => {
+export const checkoutBasket = async (oAuth: string): Promise<ApiResponse<BasketCheckout>> => {
     const api = createApiClient(undefined, oAuth, API_URL);
-    const checkoutResult:ApiResult<ApiResponse<Checkout>> = await api.basket.checkoutBasket();
+    const checkoutResult:ApiResult<ApiResponse<BasketCheckout>> = await api.basket.checkoutBasket();
     if (checkoutResult.isFailure()) {
         const errorResponse = checkoutResult.value;
         logger.error(`${errorResponse?.httpStatusCode} - ${JSON.stringify(errorResponse?.errors)}`);
@@ -68,34 +68,12 @@ export const createPayment = async (oAuth: string, paymentUrl: string, checkoutI
     }
 };
 
-export const getOrder = async (oAuth: string, orderId: string): Promise<Order> => {
-    return retryGetOrder(oAuth, orderId);
-};
-
-/*
-The order does not get created straight away which is why there is a retry method if the order is not found
-*/
-const retryGetOrder = async (oAuth: string, orderId: string, retriesLeft: number = 3, interval: number = 1000): Promise<Order> => {
+export const getCheckout = async (oAuth: string, checkoutId: string): Promise<Checkout> => {
     const api = createApiClient(undefined, oAuth, API_URL);
-    const orderResult:ApiResult<Order> = await api.order.getOrder(orderId);
-    if (orderResult.isFailure()) {
-        const errorResponse = orderResult.value;
-        if (errorResponse.httpStatusCode === 404) {
-            if (retriesLeft >= 0) {
-                logger.info(`failed to get order, order_id=${orderId}, retries=${retriesLeft}`);
-                await new Promise(resolve => setTimeout(resolve, interval));
-                return retryGetOrder(oAuth, orderId, retriesLeft - 1, interval);
-            } else {
-                throw createError(404, JSON.stringify(errorResponse?.errors) || "Unknown Error");
-            }
-        } else if (errorResponse.httpStatusCode === 401) {
-            // throw 401 error as 404, so user does not know it exists
-            logger.error(`user is unauthorized to view order, status_code=${errorResponse.httpStatusCode}, order_id=${orderId}`);
-            throw createError(404, JSON.stringify(errorResponse?.errors) || "Unknown Error");
-        } else {
-            throw createError("Unknown Error");
-        }
-    } else {
-        return orderResult.value;
-    };
+    const checkoutResource: Resource<Checkout> = await api.checkout.getCheckout(checkoutId);
+    if (checkoutResource.httpStatusCode !== 200 && checkoutResource.httpStatusCode !== 201) {
+        throw createError(checkoutResource.httpStatusCode, checkoutResource.httpStatusCode.toString());
+    }
+    logger.info(`Get checkout, status_code=${checkoutResource.httpStatusCode}`);
+    return checkoutResource.resource as Checkout;
 };

--- a/src/test/__mocks__/order.mocks.ts
+++ b/src/test/__mocks__/order.mocks.ts
@@ -1,6 +1,6 @@
-import {CertificateItemOptions, Item, Order} from "@companieshouse/api-sdk-node/dist/services/order/order";
-import {ItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
-import {CompanyType} from "../../model/CompanyType";
+import { CertificateItemOptions, Item, Order } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout"
+import { CompanyType } from "../../model/CompanyType";
 
 export const CERTIFICATE_ID = "CRT-123456-123456";
 export const CERTIFIED_COPY_ID = "CCD-123456-123456";
@@ -98,14 +98,16 @@ export const mockDissolvedCertificateItem: Item = {
     satisfiedAt: "2020-05-15T08:41:05.798Z"
 };
 
-export const mockCertificateOrderResponse: Order = {
-    orderedAt: "2019-12-16T09:16:17.791Z",
-    orderedBy: {
+export const mockCertificateCheckoutResponse: Checkout = {
+    paidAt: "2019-12-16T09:16:17.791Z",
+    status: "pending",
+    checkedOutBy: {
         id: "123456",
         email: "email@examlpe.come"
     },
     links: {
-        self: `/orders/${ORDER_ID}`
+        self: `/orders/${ORDER_ID}`,
+        payment: `"/basket/checkouts/${ORDER_ID}/payment"`
     },
     paymentReference: "1234567",
     etag: "abcdefghijk123456789",
@@ -126,14 +128,16 @@ export const mockCertificateOrderResponse: Order = {
     reference: ORDER_ID
 };
 
-export const mockDissolvedCertificateOrderResponse: Order = {
-    orderedAt: "2019-12-16T09:16:17.791Z",
-    orderedBy: {
+export const mockDissolvedCertificateCheckoutResponse: Checkout = {
+    paidAt: "2019-12-16T09:16:17.791Z",
+    status: "pending",
+    checkedOutBy: {
         id: "123456",
         email: "email@examlpe.come"
     },
     links: {
-        self: `/orders/${ORDER_ID}`
+        self: `/orders/${ORDER_ID}`,
+        payment: `"/basket/checkouts/${ORDER_ID}/payment"`
     },
     paymentReference: "1234567",
     etag: "abcdefghijk123456789",
@@ -211,14 +215,16 @@ export const mockCertifiedCopyItem: Item = {
     satisfiedAt: "2020-05-15T08:41:05.798Z"
 };
 
-export const mockCertifiedCopyOrderResponse: Order = {
-    orderedAt: "2019-12-16T09:16:17.791Z",
-    orderedBy: {
+export const mockCertifiedCopyCheckoutResponse: Checkout = {
+    paidAt: "2019-12-16T09:16:17.791Z",
+    status: "pending",
+    checkedOutBy: {
         id: "123456",
         email: "email@examlpe.come"
     },
     links: {
-        self: `/orders/${ORDER_ID}`
+        self: `/orders/${ORDER_ID}`,
+        payment: `"/basket/checkouts/${ORDER_ID}/payment"`
     },
     paymentReference: "1234567",
     etag: "abcdefghijk123456789",
@@ -279,19 +285,21 @@ export const mockMissingImageDeliveryItem: Item = {
     postalDelivery: false
 };
 
-export const mockMissingImageDeliveryOrderResponse: Order = {
+export const mockMissingImageDeliveryCheckoutResponse: Checkout = {
     paymentReference: "q4nn5UxZiZxVG2e",
     etag: "80bd2953c79729aa0885f6987208690341376db0",
     items: [mockMissingImageDeliveryItem],
     kind: "order",
     totalOrderCost: "3",
     reference: ORDER_ID,
-    orderedAt: "2020-10-07T11:09:46.196",
-    orderedBy: {
-        email: "demo@ch.gov.uk",
-        id: "67ZeMsvAEgkBWs7tNKacdrPvOmQ"
+    paidAt: "2020-10-07T11:09:46.196",
+    status: "pending",
+    checkedOutBy: {
+        id: "123456",
+        email: "email@example.come"
     },
     links: {
-        self: "/orders/" + ORDER_ID
+        self: "/orders/" + ORDER_ID,
+        payment: `"/basket/checkouts/${ORDER_ID}/payment"`
     }
 };


### PR DESCRIPTION
The order confirmation page that currently exists uses the data from the getOrder method. This is problematic as depending on the speed of the order completion, a user can end up on the order confirmation screen before the order is created. To resolve the race condition it will now take its data from the getCheckout response.

Resolves: BI-6863