### PR TITLE
BI-9545 Upgrade api-sdk-node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.66",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.66.tgz",
-      "integrity": "sha512-DjAJ8R6fJmw7aE20vfpyZCqPsUk2rH5ZltNf1L2aoXU145KsOve6SVTnx+sY5zWuMm1Lb2XtAjMV+NI82XLAmA==",
+      "version": "1.0.88",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.88.tgz",
+      "integrity": "sha512-NJ6APot3ihzig13MFL+kwcFhvyTB5yEP5pX9lrrELeu5W/lC4745WWyFTMOqNmmxNqFladodd+SjneLQDHm4TQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.66",
+    "@companieshouse/api-sdk-node": "^1.0.88",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",


### PR DESCRIPTION
- Upgrade to api-sdk-node 1.0.88

Resolves: [BI-9545 Upgrade api-sdk-node version: orders.web.ch.gov.uk](https://companieshouse.atlassian.net/browse/BI-9545)