### PR TITLE
BI-10172 - Upgrade api-sdk-node to 1.0.90

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.88",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.88.tgz",
-      "integrity": "sha512-NJ6APot3ihzig13MFL+kwcFhvyTB5yEP5pX9lrrELeu5W/lC4745WWyFTMOqNmmxNqFladodd+SjneLQDHm4TQ==",
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.90.tgz",
+      "integrity": "sha512-YlaOdsJq867M5Yfa9Xwzqk8YmurqEYeFmkKjnTRK2RDdb6U5mt2yy8RjqOlxVn8bPc9APDNl+CD+wSsmyiesWg==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.88",
+    "@companieshouse/api-sdk-node": "^1.0.90",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",


### PR DESCRIPTION
- Upgrades api-sdk-node to version 1.0.90.
- Tested certificates journey locally, works fine.

[BI-10172](https://companieshouse.atlassian.net/browse/BI-10172)