### PR TITLE
BI-8850 Implement mapper for liquidated company certs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.90",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.90.tgz",
-      "integrity": "sha512-YlaOdsJq867M5Yfa9Xwzqk8YmurqEYeFmkKjnTRK2RDdb6U5mt2yy8RjqOlxVn8bPc9APDNl+CD+wSsmyiesWg==",
+      "version": "1.0.93",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.93.tgz",
+      "integrity": "sha512-uqnrww58F03YO1tdEO7bU9sw6ZdPfAsIaX3HoDlVxMKOvlEH86xhjKsb9dxY21/aWKE8WuQk/ncRJvBz+zvJOg==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.90",
+    "@companieshouse/api-sdk-node": "^1.0.93",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/src/config/FeatureFlags.ts
+++ b/src/config/FeatureFlags.ts
@@ -1,7 +1,11 @@
-import {DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED, DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED} from "./config";
+import {
+    CERTS_FOR_LIQUIDATED_COMPANIES,
+    DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED,
+    DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED
+} from "./config";
 
 export class FeatureFlags {
-    constructor(private _lpCertificateOrdersEnabled: boolean, private _llpCertificateOrdersEnabled: boolean) {
+    constructor(private _lpCertificateOrdersEnabled: boolean, private _llpCertificateOrdersEnabled: boolean, private _liquidationEnabled: boolean) {
     }
 
     get lpCertificateOrdersEnabled(): boolean {
@@ -19,6 +23,14 @@ export class FeatureFlags {
     set llpCertificateOrdersEnabled(value: boolean) {
         this._llpCertificateOrdersEnabled = value;
     }
+
+    get liquidationEnabled (): boolean {
+        return this._liquidationEnabled;
+    }
+
+    set liquidationEnabled (value: boolean) {
+        this._liquidationEnabled = value;
+    }
 }
 
-export const FEATURE_FLAGS = new FeatureFlags(DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED, DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED)
+export const FEATURE_FLAGS = new FeatureFlags(DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED, DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED, CERTS_FOR_LIQUIDATED_COMPANIES);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,3 +40,5 @@ export const DISPATCH_DAYS = getEnvironmentValue("DISPATCH_DAYS");
 export const DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED = getEnvironmentValue("DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED", "false") === "true";
 
 export const DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED = getEnvironmentValue("DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED", "false") === "true";
+
+export const CERTS_FOR_LIQUIDATED_COMPANIES = getEnvironmentValue("CERTS_FOR_LIQUIDATED_COMPANIES", "false") === "true";

--- a/src/model/CompanyStatus.ts
+++ b/src/model/CompanyStatus.ts
@@ -1,0 +1,4 @@
+export enum CompanyStatus {
+    ACTIVE = "active",
+    LIQUIDATION = "liquidation"
+}

--- a/src/service/ItemMapperFactory.ts
+++ b/src/service/ItemMapperFactory.ts
@@ -1,28 +1,26 @@
-import {ItemMapper} from "./ItemMapper";
-import { CompanyStatus } from "../model/CompanyStatus";
+import { ItemMapper } from "./ItemMapper";
 import { CompanyType } from "../model/CompanyType";
+import { CompanyStatus } from "../model/CompanyStatus";
 
 export class ItemMapperFactory {
     private readonly factoryMap: Map<string, Map<string, () => ItemMapper>>;
+    static defaultMapping = "default";
 
-    public constructor(typeSpecificItemMappers: [string,  Map<string, () => ItemMapper>][], private readonly defaultMapper: () => ItemMapper) {
+    public constructor (typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][], private readonly defaultMapper: () => ItemMapper) {
         this.factoryMap = new Map<string, Map<string, () => ItemMapper>>(typeSpecificItemMappers);
     }
 
     getItemMapper = (companyType: CompanyType | string, companyStatus: CompanyStatus | string): ItemMapper => {
-        const defaultMapping = "default";
+        let typeMappings: Map<string, () => ItemMapper>;
         if (this.factoryMap.has(companyType)) {
-            if (this.factoryMap.get(companyType)?.has(companyStatus)) {
-                return (this.factoryMap.get(companyType)?.get(companyStatus) || this.defaultMapper)()
-            } else {
-                return (this.factoryMap.get(companyType)?.get(defaultMapping) || this.defaultMapper)()
-            }
+            typeMappings = this.factoryMap?.get(companyType) || new Map<string, () => ItemMapper>();
         } else {
-            if (this.factoryMap.get(defaultMapping)?.has(companyStatus)) {
-                return (this.factoryMap.get(defaultMapping)?.get(companyStatus) || this.defaultMapper)()
-            } else {
-                return (this.factoryMap.get(defaultMapping)?.get(defaultMapping) || this.defaultMapper)()
-            }
+            typeMappings = this.factoryMap?.get(ItemMapperFactory.defaultMapping) || new Map<string, () => ItemMapper>();
         }
-    }
+        if (typeMappings.has(companyStatus)) {
+            return (typeMappings?.get(companyStatus) || this.defaultMapper)();
+        } else {
+            return (typeMappings?.get(ItemMapperFactory.defaultMapping) || this.defaultMapper)();
+        }
+    };
 }

--- a/src/service/ItemMapperFactory.ts
+++ b/src/service/ItemMapperFactory.ts
@@ -1,14 +1,28 @@
 import {ItemMapper} from "./ItemMapper";
-import {CompanyType} from "../model/CompanyType";
+import { CompanyStatus } from "../model/CompanyStatus";
+import { CompanyType } from "../model/CompanyType";
 
 export class ItemMapperFactory {
-    private readonly factoryMap: Map<string, () => ItemMapper>;
+    private readonly factoryMap: Map<string, Map<string, () => ItemMapper>>;
 
-    public constructor(typeSpecificItemMappers: [CompanyType,  () => ItemMapper][], private readonly defaultItemMapper: () => ItemMapper) {
-        this.factoryMap = new Map<CompanyType, () => ItemMapper>(typeSpecificItemMappers);
+    public constructor(typeSpecificItemMappers: [string,  Map<string, () => ItemMapper>][], private readonly defaultMapper: () => ItemMapper) {
+        this.factoryMap = new Map<string, Map<string, () => ItemMapper>>(typeSpecificItemMappers);
     }
 
-    getItemMapper = (companyType: CompanyType | string): ItemMapper => {
-        return (this.factoryMap.get(companyType) || this.defaultItemMapper)();
+    getItemMapper = (companyType: CompanyType | string, companyStatus: CompanyStatus | string): ItemMapper => {
+        const defaultMapping = "default";
+        if (this.factoryMap.has(companyType)) {
+            if (this.factoryMap.get(companyType)?.has(companyStatus)) {
+                return (this.factoryMap.get(companyType)?.get(companyStatus) || this.defaultMapper)()
+            } else {
+                return (this.factoryMap.get(companyType)?.get(defaultMapping) || this.defaultMapper)()
+            }
+        } else {
+            if (this.factoryMap.get(defaultMapping)?.has(companyStatus)) {
+                return (this.factoryMap.get(defaultMapping)?.get(companyStatus) || this.defaultMapper)()
+            } else {
+                return (this.factoryMap.get(defaultMapping)?.get(defaultMapping) || this.defaultMapper)()
+            }
+        }
     }
 }

--- a/src/service/ItemMapperFactory.ts
+++ b/src/service/ItemMapperFactory.ts
@@ -2,6 +2,8 @@ import { ItemMapper } from "./ItemMapper";
 import { CompanyType } from "../model/CompanyType";
 import { CompanyStatus } from "../model/CompanyStatus";
 
+export type CompanyDetail = { companyType: CompanyType | string, companyStatus: CompanyStatus | string };
+
 export class ItemMapperFactory {
     private readonly factoryMap: Map<string, Map<string, () => ItemMapper>>;
     static defaultMapping = "default";
@@ -10,15 +12,15 @@ export class ItemMapperFactory {
         this.factoryMap = new Map<string, Map<string, () => ItemMapper>>(typeSpecificItemMappers);
     }
 
-    getItemMapper = (companyType: CompanyType | string, companyStatus: CompanyStatus | string): ItemMapper => {
+    getItemMapper = (item: CompanyDetail): ItemMapper => {
         let typeMappings: Map<string, () => ItemMapper>;
-        if (this.factoryMap.has(companyType)) {
-            typeMappings = this.factoryMap?.get(companyType) || new Map<string, () => ItemMapper>();
+        if (this.factoryMap.has(item.companyType)) {
+            typeMappings = this.factoryMap?.get(item.companyType) || new Map<string, () => ItemMapper>();
         } else {
             typeMappings = this.factoryMap?.get(ItemMapperFactory.defaultMapping) || new Map<string, () => ItemMapper>();
         }
-        if (typeMappings.has(companyStatus)) {
-            return (typeMappings?.get(companyStatus) || this.defaultMapper)();
+        if (typeMappings.has(item.companyStatus)) {
+            return (typeMappings?.get(item.companyStatus) || this.defaultMapper)();
         } else {
             return (typeMappings?.get(ItemMapperFactory.defaultMapping) || this.defaultMapper)();
         }

--- a/src/service/ItemMapperFactoryConfig.ts
+++ b/src/service/ItemMapperFactoryConfig.ts
@@ -5,26 +5,33 @@ import {ItemMapper} from "./ItemMapper";
 import {LLPCertificateItemMapper} from "./LLPCertificateItemMapper";
 import {LPCertificateItemMapper} from "./LPCertificateItemMapper";
 import {FEATURE_FLAGS, FeatureFlags} from "../config/FeatureFlags";
+import { CompanyStatus } from "../model/CompanyStatus";
+import { LiquidatedOtherCertificateItemMapper } from "./LiquidatedOtherCertificateItemMapper";
+import { NullItemMapper } from "./NullItemMapper";
 
 export class ItemMapperFactoryConfig {
     public constructor(private readonly featureFlags: FeatureFlags) {
     }
 
     getInstance = () => {
-        const typeSpecificItemMappers: [CompanyType, () => ItemMapper][] = [];
+        const typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][] = [];
         if (this.featureFlags.llpCertificateOrdersEnabled) {
-            typeSpecificItemMappers.push([CompanyType.LIMITED_LIABILITY_PARTNERSHIP, () => {
-                return new LLPCertificateItemMapper()
-            }]);
+            typeSpecificItemMappers.push([CompanyType.LIMITED_LIABILITY_PARTNERSHIP, new Map<string, () => ItemMapper>([
+                ["default", () => {return new LLPCertificateItemMapper()}]
+            ])]);
         }
         if (this.featureFlags.lpCertificateOrdersEnabled) {
-            typeSpecificItemMappers.push([CompanyType.LIMITED_PARTNERSHIP, () => {
-                return new LPCertificateItemMapper()
-            }]);
+            typeSpecificItemMappers.push([CompanyType.LIMITED_PARTNERSHIP, new Map<string, () => ItemMapper>([
+                ["default", () => {return new LPCertificateItemMapper()}]
+            ])]);
         }
+        typeSpecificItemMappers.push(["default", new Map<string, () => ItemMapper>([
+            [CompanyStatus.LIQUIDATION, () => {return new LiquidatedOtherCertificateItemMapper()}],
+            ["default", () => {return new OtherCertificateItemMapper()}]
+        ])]);
 
         return new ItemMapperFactory(typeSpecificItemMappers, () => {
-            return new OtherCertificateItemMapper()
+            return new NullItemMapper()
         });
     }
 }

--- a/src/service/ItemMapperFactoryConfig.ts
+++ b/src/service/ItemMapperFactoryConfig.ts
@@ -1,38 +1,59 @@
-import {ItemMapperFactory} from "./ItemMapperFactory";
-import {OtherCertificateItemMapper} from "./OtherCertificateItemMapper";
-import {CompanyType} from "../model/CompanyType";
-import {ItemMapper} from "./ItemMapper";
-import {LLPCertificateItemMapper} from "./LLPCertificateItemMapper";
-import {LPCertificateItemMapper} from "./LPCertificateItemMapper";
-import {FEATURE_FLAGS, FeatureFlags} from "../config/FeatureFlags";
+import { ItemMapperFactory } from "./ItemMapperFactory";
+import { OtherCertificateItemMapper } from "./OtherCertificateItemMapper";
+import { CompanyType } from "../model/CompanyType";
+import { ItemMapper } from "./ItemMapper";
+import { LLPCertificateItemMapper } from "./LLPCertificateItemMapper";
+import { LPCertificateItemMapper } from "./LPCertificateItemMapper";
+import { FEATURE_FLAGS, FeatureFlags } from "../config/FeatureFlags";
 import { CompanyStatus } from "../model/CompanyStatus";
 import { LiquidatedOtherCertificateItemMapper } from "./LiquidatedOtherCertificateItemMapper";
 import { NullItemMapper } from "./NullItemMapper";
+import { LiquidatedLLPCertificateItemMapper } from "./LiquidatedLLPCertificateItemMapper";
 
 export class ItemMapperFactoryConfig {
-    public constructor(private readonly featureFlags: FeatureFlags) {
+    public constructor (private readonly featureFlags: FeatureFlags) {
     }
 
     getInstance = () => {
         const typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][] = [];
         if (this.featureFlags.llpCertificateOrdersEnabled) {
-            typeSpecificItemMappers.push([CompanyType.LIMITED_LIABILITY_PARTNERSHIP, new Map<string, () => ItemMapper>([
-                ["default", () => {return new LLPCertificateItemMapper()}]
-            ])]);
+            this.setupLLPItemMappers(typeSpecificItemMappers);
         }
         if (this.featureFlags.lpCertificateOrdersEnabled) {
-            typeSpecificItemMappers.push([CompanyType.LIMITED_PARTNERSHIP, new Map<string, () => ItemMapper>([
-                ["default", () => {return new LPCertificateItemMapper()}]
-            ])]);
+            this.setupLPItemMappers(typeSpecificItemMappers);
         }
-        typeSpecificItemMappers.push(["default", new Map<string, () => ItemMapper>([
-            [CompanyStatus.LIQUIDATION, () => {return new LiquidatedOtherCertificateItemMapper()}],
-            ["default", () => {return new OtherCertificateItemMapper()}]
-        ])]);
-
+        this.setupDefaultItemMappers(typeSpecificItemMappers);
         return new ItemMapperFactory(typeSpecificItemMappers, () => {
-            return new NullItemMapper()
+            return new NullItemMapper();
         });
+    };
+
+    private setupLLPItemMappers (typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][]) {
+        const llpMappers: [string, () => ItemMapper][] = [
+            [ItemMapperFactory.defaultMapping, () => new LLPCertificateItemMapper()]
+        ];
+        if (this.featureFlags.liquidationEnabled) {
+            llpMappers.push([CompanyStatus.LIQUIDATION, () => new LiquidatedLLPCertificateItemMapper()]);
+        }
+        typeSpecificItemMappers.push([CompanyType.LIMITED_LIABILITY_PARTNERSHIP, new Map<string, () => ItemMapper>(llpMappers)]);
+    }
+
+    private setupLPItemMappers (typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][]) {
+        typeSpecificItemMappers.push([CompanyType.LIMITED_PARTNERSHIP, new Map<string, () => ItemMapper>([
+            [ItemMapperFactory.defaultMapping, () => {
+                return new LPCertificateItemMapper();
+            }]
+        ])]);
+    }
+
+    private setupDefaultItemMappers (typeSpecificItemMappers: [string, Map<string, () => ItemMapper>][]) {
+        const defaultMappers: [string, () => ItemMapper][] = [
+            [ItemMapperFactory.defaultMapping, () => new OtherCertificateItemMapper()]
+        ];
+        if (this.featureFlags.liquidationEnabled) {
+            defaultMappers.push([CompanyStatus.LIQUIDATION, () => new LiquidatedOtherCertificateItemMapper()]);
+        }
+        typeSpecificItemMappers.push([ItemMapperFactory.defaultMapping, new Map<string, () => ItemMapper>(defaultMappers)]);
     }
 }
 

--- a/src/service/LPCertificateItemMapper.ts
+++ b/src/service/LPCertificateItemMapper.ts
@@ -1,14 +1,10 @@
-import {ItemMapper} from "./ItemMapper";
-import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
-import {createLogger} from "ch-structured-logging";
-import {APPLICATION_NAME} from "../config/config";
-import {MapUtil} from "./MapUtil";
-
-const logger = createLogger(APPLICATION_NAME);
+import { ItemMapper } from "./ItemMapper";
+import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { MapUtil } from "./MapUtil";
 
 export class LPCertificateItemMapper extends ItemMapper {
 
-    getOrdersDetailTable(item: { companyName: string, companyNumber: string, itemOptions: CertificateItemOptions }): any {
+    getOrdersDetailTable (item: { companyName: string, companyNumber: string, itemOptions: CertificateItemOptions }): any {
         return [
             {
                 key: {
@@ -54,7 +50,7 @@ export class LPCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='principalPlaceOfBusiness'>" + this.mapPrincipalPlaceOfBusiness(item.itemOptions) + "</p>"
+                    html: "<p id='principalPlaceOfBusiness'>" + MapUtil.mapAddressOptions(item.itemOptions?.principalPlaceOfBusinessDetails) + "</p>"
                 }
             },
             {
@@ -106,9 +102,5 @@ export class LPCertificateItemMapper extends ItemMapper {
                 }
             }
         ];
-    }
-
-    mapPrincipalPlaceOfBusiness = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions?.principalPlaceOfBusinessDetails);
     }
 }

--- a/src/service/LiquidatedLLPCertificateItemMapper.ts
+++ b/src/service/LiquidatedLLPCertificateItemMapper.ts
@@ -2,7 +2,7 @@ import {ItemMapper} from "./ItemMapper";
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {MapUtil} from "./MapUtil";
 
-export class LLPCertificateItemMapper extends ItemMapper {
+export class LiquidatedLLPCertificateItemMapper extends ItemMapper {
 
     getOrdersDetailTable(item: { companyName: string, companyNumber: string, itemOptions: CertificateItemOptions }): any {
 
@@ -34,15 +34,6 @@ export class LLPCertificateItemMapper extends ItemMapper {
                 value: {
                     classes: "govuk-!-width-one-half",
                     html: "<p id='certificateTypeValue'>" + this.mapCertificateType(item.itemOptions.certificateType) + "</p>"
-                }
-            },
-            {
-                key: {
-                    text: "Statement of good standing"
-                },
-                value: {
-                    classes: "govuk-!-width-one-half",
-                    html: "<p id='statementOfGoodStandingValue'>" + MapUtil.determineItemOptionsSelectedText(item.itemOptions.includeGoodStandingInformation) + "</p>"
                 }
             },
             {
@@ -82,6 +73,22 @@ export class LLPCertificateItemMapper extends ItemMapper {
                     items: [
                         {
                             visuallyHiddenText: "current members names"
+                        }
+                    ]
+                }
+            },
+            {
+                key: {
+                    text: "Liquidators' details"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='liquidators'>" + MapUtil.determineItemOptionsSelectedText(item.itemOptions.liquidatorsDetails?.includeBasicInformation) + "</p>"
+                },
+                actions: {
+                    items: [
+                        {
+                            visuallyHiddenText: "liquidators' details"
                         }
                     ]
                 }

--- a/src/service/LiquidatedOtherCertificateItemMapper.ts
+++ b/src/service/LiquidatedOtherCertificateItemMapper.ts
@@ -1,0 +1,89 @@
+import {ItemMapper} from "./ItemMapper";
+import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
+import {createLogger} from "ch-structured-logging";
+import {APPLICATION_NAME} from "../config/config";
+import {MapUtil} from "./MapUtil";
+
+const logger = createLogger(APPLICATION_NAME);
+
+export class LiquidatedOtherCertificateItemMapper extends ItemMapper {
+
+    getOrdersDetailTable(item: {companyName: string,  companyNumber: string, itemOptions: CertificateItemOptions}): any {
+        return [
+            {
+                key: {
+                    text: "Company name",
+                    classes: "govuk-!-width-one-half"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='companyNameValue'>" + item.companyName + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Company number"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='companyNumberValue'>" + item.companyNumber + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Certificate type",
+                    classes: "govuk-!-width-one-half"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='certificateTypeValue'>" + this.mapCertificateType(item.itemOptions.certificateType) + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Registered office address"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapRegisteredOfficeAddress(item.itemOptions) + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "The names of all current company directors"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='currentCompanyDirectors'>" + MapUtil.determineDirectorOrSecretaryOptionsText(item.itemOptions.directorDetails, "directors") + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "The names of all current company secretaries"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='currentCompanySecretaries'>" + MapUtil.determineDirectorOrSecretaryOptionsText(item.itemOptions.secretaryDetails, "secretaries") + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Company objects"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='companyObjects'>" + MapUtil.determineItemOptionsSelectedText(item.itemOptions.includeCompanyObjectsInformation) + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Liquidators' details"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='liquidators'>" + MapUtil.determineItemOptionsSelectedText(item.itemOptions.liquidatorsDetails?.includeBasicInformation) + "</p>"
+                }
+            },
+        ]
+    }
+}

--- a/src/service/LiquidatedOtherCertificateItemMapper.ts
+++ b/src/service/LiquidatedOtherCertificateItemMapper.ts
@@ -1,10 +1,6 @@
 import {ItemMapper} from "./ItemMapper";
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
-import {createLogger} from "ch-structured-logging";
-import {APPLICATION_NAME} from "../config/config";
 import {MapUtil} from "./MapUtil";
-
-const logger = createLogger(APPLICATION_NAME);
 
 export class LiquidatedOtherCertificateItemMapper extends ItemMapper {
 
@@ -45,7 +41,7 @@ export class LiquidatedOtherCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapRegisteredOfficeAddress(item.itemOptions) + "</p>"
+                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapAddressOptions(item.itemOptions?.registeredOfficeAddressDetails) + "</p>"
                 }
             },
             {

--- a/src/service/MapUtil.ts
+++ b/src/service/MapUtil.ts
@@ -1,6 +1,8 @@
 import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
-import { DirectorOrSecretaryDetails } from "@companieshouse/api-sdk-node/dist/services/order/certificates";
-import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import {
+    DirectorOrSecretaryDetails,
+    MemberDetails
+} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
 import { createLogger } from "ch-structured-logging";
 import { AddressRecordsType } from "model/AddressRecordsType";
 import { APPLICATION_NAME, DISPATCH_DAYS } from "../config/config";
@@ -104,10 +106,6 @@ export abstract class MapUtil {
         }
     }
 
-    static mapRegisteredOfficeAddress = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions?.registeredOfficeAddressDetails);
-    }
-
     static determineDirectorOrSecretaryOptionsText = (directorOrSecretaryDetails: DirectorOrSecretaryDetails, officer: string) => {
         if (directorOrSecretaryDetails === undefined || !directorOrSecretaryDetails.includeBasicInformation) {
             return "No";
@@ -138,5 +136,41 @@ export abstract class MapUtil {
             return "Yes";
         }
         return MapUtil.mapToHtml(directorOrSecretaryOptions);
+    }
+
+    static mapMembersOptions = (heading: string, memberOptions?: MemberDetails): string => {
+        if (memberOptions === undefined || memberOptions.includeBasicInformation === undefined) {
+            return "No";
+        }
+
+        if (memberOptions.includeBasicInformation === true &&
+            memberOptions.includeAddress === false &&
+            memberOptions.includeAppointmentDate === false &&
+            memberOptions.includeCountryOfResidence === false &&
+            memberOptions.includeDobType === undefined) {
+            return "Yes";
+        }
+
+        const membersMappings: string[] = [];
+        membersMappings.push(heading);
+
+        if (memberOptions.includeAddress) {
+            membersMappings.push("Correspondence address");
+        }
+
+        if (memberOptions.includeAppointmentDate) {
+            membersMappings.push("Appointment date");
+        }
+
+        if (memberOptions.includeCountryOfResidence) {
+            membersMappings.push("Country of residence");
+        }
+
+        if (memberOptions.includeDobType === "partial" ||
+            memberOptions.includeDobType === "full") {
+            membersMappings.push("Date of birth (month and year)");
+        }
+
+        return MapUtil.mapToHtml(membersMappings);
     }
 }

--- a/src/service/MapUtil.ts
+++ b/src/service/MapUtil.ts
@@ -1,4 +1,6 @@
 import { DeliveryDetails } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { DirectorOrSecretaryDetails } from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
 import { createLogger } from "ch-structured-logging";
 import { AddressRecordsType } from "model/AddressRecordsType";
 import { APPLICATION_NAME, DISPATCH_DAYS } from "../config/config";
@@ -100,5 +102,41 @@ export abstract class MapUtil {
                 logger.error(`Unable to map value for registered office address options: ${addressDetails.includeAddressRecordsType}`);
                 return "";
         }
+    }
+
+    static mapRegisteredOfficeAddress = (itemOptions: CertificateItemOptions): string => {
+        return MapUtil.mapAddressOptions(itemOptions?.registeredOfficeAddressDetails);
+    }
+
+    static determineDirectorOrSecretaryOptionsText = (directorOrSecretaryDetails: DirectorOrSecretaryDetails, officer: string) => {
+        if (directorOrSecretaryDetails === undefined || !directorOrSecretaryDetails.includeBasicInformation) {
+            return "No";
+        }
+        const directorOrSecretaryOptions: string[] = [];
+
+        if (directorOrSecretaryDetails.includeAddress) {
+            directorOrSecretaryOptions.push("Correspondence address");
+        }
+        if (directorOrSecretaryDetails.includeOccupation) {
+            directorOrSecretaryOptions.push("Occupation");
+        }
+        if (directorOrSecretaryDetails.includeDobType === "partial") {
+            directorOrSecretaryOptions.push("Date of birth (month and year)");
+        }
+        if (directorOrSecretaryDetails.includeAppointmentDate) {
+            directorOrSecretaryOptions.push("Appointment date");
+        }
+        if (directorOrSecretaryDetails.includeNationality) {
+            directorOrSecretaryOptions.push("Nationality");
+        }
+        if (directorOrSecretaryDetails.includeCountryOfResidence) {
+            directorOrSecretaryOptions.push("Country of residence");
+        }
+        if (directorOrSecretaryOptions.length > 0) {
+            directorOrSecretaryOptions.unshift("Including " + officer + "':", "");
+        } else {
+            return "Yes";
+        }
+        return MapUtil.mapToHtml(directorOrSecretaryOptions);
     }
 }

--- a/src/service/NullItemMapper.ts
+++ b/src/service/NullItemMapper.ts
@@ -1,0 +1,8 @@
+import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { ItemMapper } from "./ItemMapper";
+
+export class NullItemMapper extends ItemMapper {
+  getOrdersDetailTable(item: { companyName: string; companyNumber: string; itemOptions: CertificateItemOptions; }) {
+    throw new Error("Mapper not found");
+  }
+}

--- a/src/service/NullItemMapper.ts
+++ b/src/service/NullItemMapper.ts
@@ -2,7 +2,7 @@ import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/servic
 import { ItemMapper } from "./ItemMapper";
 
 export class NullItemMapper extends ItemMapper {
-  getOrdersDetailTable(item: { companyName: string; companyNumber: string; itemOptions: CertificateItemOptions; }) {
-    throw new Error("Mapper not found");
-  }
+    getOrdersDetailTable (item: { companyName: string; companyNumber: string; itemOptions: CertificateItemOptions; }) {
+        throw new Error("Mapper not found");
+    }
 }

--- a/src/service/OtherCertificateItemMapper.ts
+++ b/src/service/OtherCertificateItemMapper.ts
@@ -1,8 +1,5 @@
 import {ItemMapper} from "./ItemMapper";
-import {
-    CertificateItemOptions,
-    DirectorOrSecretaryDetails
-} from "@companieshouse/api-sdk-node/dist/services/order/order";
+import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {createLogger} from "ch-structured-logging";
 import {APPLICATION_NAME} from "../config/config";
 import {MapUtil} from "./MapUtil";
@@ -57,7 +54,7 @@ export class OtherCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='registeredOfficeAddress'>" + this.mapRegisteredOfficeAddress(item.itemOptions) + "</p>"
+                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapRegisteredOfficeAddress(item.itemOptions) + "</p>"
                 }
             },
             {
@@ -66,7 +63,7 @@ export class OtherCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='currentCompanyDirectors'>" + this.determineDirectorOrSecretaryOptionsText(item.itemOptions.directorDetails, "directors") + "</p>"
+                    html: "<p id='currentCompanyDirectors'>" + MapUtil.determineDirectorOrSecretaryOptionsText(item.itemOptions.directorDetails, "directors") + "</p>"
                 }
             },
             {
@@ -75,7 +72,7 @@ export class OtherCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='currentCompanySecretaries'>" + this.determineDirectorOrSecretaryOptionsText(item.itemOptions.secretaryDetails, "secretaries") + "</p>"
+                    html: "<p id='currentCompanySecretaries'>" + MapUtil.determineDirectorOrSecretaryOptionsText(item.itemOptions.secretaryDetails, "secretaries") + "</p>"
                 }
             },
             {
@@ -88,41 +85,5 @@ export class OtherCertificateItemMapper extends ItemMapper {
                 }
             }
         ]
-    }
-
-    mapRegisteredOfficeAddress = (itemOptions: CertificateItemOptions): string => {
-        return MapUtil.mapAddressOptions(itemOptions?.registeredOfficeAddressDetails);
-    }
-
-    determineDirectorOrSecretaryOptionsText = (directorOrSecretaryDetails: DirectorOrSecretaryDetails, officer: string) => {
-        if (directorOrSecretaryDetails === undefined || !directorOrSecretaryDetails.includeBasicInformation) {
-            return "No";
-        }
-        const directorOrSecretaryOptions: string[] = [];
-
-        if (directorOrSecretaryDetails.includeAddress) {
-            directorOrSecretaryOptions.push("Correspondence address");
-        }
-        if (directorOrSecretaryDetails.includeOccupation) {
-            directorOrSecretaryOptions.push("Occupation");
-        }
-        if (directorOrSecretaryDetails.includeDobType === "partial") {
-            directorOrSecretaryOptions.push("Date of birth (month and year)");
-        }
-        if (directorOrSecretaryDetails.includeAppointmentDate) {
-            directorOrSecretaryOptions.push("Appointment date");
-        }
-        if (directorOrSecretaryDetails.includeNationality) {
-            directorOrSecretaryOptions.push("Nationality");
-        }
-        if (directorOrSecretaryDetails.includeCountryOfResidence) {
-            directorOrSecretaryOptions.push("Country of residence");
-        }
-        if (directorOrSecretaryOptions.length > 0) {
-            directorOrSecretaryOptions.unshift("Including " + officer + "':", "");
-        } else {
-            return "Yes";
-        }
-        return MapUtil.mapToHtml(directorOrSecretaryOptions);
     }
 }

--- a/src/service/OtherCertificateItemMapper.ts
+++ b/src/service/OtherCertificateItemMapper.ts
@@ -1,10 +1,6 @@
 import {ItemMapper} from "./ItemMapper";
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
-import {createLogger} from "ch-structured-logging";
-import {APPLICATION_NAME} from "../config/config";
 import {MapUtil} from "./MapUtil";
-
-const logger = createLogger(APPLICATION_NAME);
 
 export class OtherCertificateItemMapper extends ItemMapper {
 
@@ -54,7 +50,7 @@ export class OtherCertificateItemMapper extends ItemMapper {
                 },
                 value: {
                     classes: "govuk-!-width-one-half",
-                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapRegisteredOfficeAddress(item.itemOptions) + "</p>"
+                    html: "<p id='registeredOfficeAddress'>" + MapUtil.mapAddressOptions(item.itemOptions?.registeredOfficeAddressDetails) + "</p>"
                 }
             },
             {

--- a/src/service/map.item.service.ts
+++ b/src/service/map.item.service.ts
@@ -23,7 +23,8 @@ export const mapItem = (item: Item, deliveryDetails: DeliveryDetails | undefined
     if (itemKind === "item#certificate") {
         const itemOptions = item.itemOptions as CertificateItemOptions;
         if (itemOptions.certificateType === "incorporation-with-all-name-changes") {
-            return itemMapperFactory.getItemMapper(itemOptions.companyType, itemOptions.companyStatus).getCheckDetailsItem({companyName: item?.companyName, companyNumber: item?.companyNumber, itemOptions, deliveryDetails});
+            return itemMapperFactory.getItemMapper({ companyType: itemOptions.companyType, companyStatus: itemOptions.companyStatus } )
+                .getCheckDetailsItem({companyName: item?.companyName, companyNumber: item?.companyNumber, itemOptions, deliveryDetails});
         } else {
             const deliveryMethod = MapUtil.mapDeliveryMethod(item?.itemOptions);
             const address = MapUtil.mapDeliveryDetails(deliveryDetails);

--- a/src/service/map.item.service.ts
+++ b/src/service/map.item.service.ts
@@ -23,7 +23,7 @@ export const mapItem = (item: Item, deliveryDetails: DeliveryDetails | undefined
     if (itemKind === "item#certificate") {
         const itemOptions = item.itemOptions as CertificateItemOptions;
         if (itemOptions.certificateType === "incorporation-with-all-name-changes") {
-            return itemMapperFactory.getItemMapper(itemOptions.companyType).getCheckDetailsItem({companyName: item?.companyName, companyNumber: item?.companyNumber, itemOptions, deliveryDetails});
+            return itemMapperFactory.getItemMapper(itemOptions.companyType, itemOptions.companyStatus).getCheckDetailsItem({companyName: item?.companyName, companyNumber: item?.companyNumber, itemOptions, deliveryDetails});
         } else {
             const deliveryMethod = MapUtil.mapDeliveryMethod(item?.itemOptions);
             const address = MapUtil.mapDeliveryDetails(deliveryDetails);

--- a/src/test/service/ItemMapperFactory.unit.test.ts
+++ b/src/test/service/ItemMapperFactory.unit.test.ts
@@ -35,7 +35,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(OtherCertificateItemMapper);
@@ -47,7 +47,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(OtherCertificateItemMapper);
@@ -59,7 +59,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LPCertificateItemMapper);
@@ -71,7 +71,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LLPCertificateItemMapper);
@@ -83,7 +83,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.LIQUIDATION;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LiquidatedOtherCertificateItemMapper);
@@ -95,7 +95,7 @@ describe("ItemMapperFactory unit tests", () => {
             const companyStatus = CompanyStatus.LIQUIDATION;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+            const itemMapper = itemMapperFactory.getItemMapper({companyType, companyStatus});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LiquidatedLLPCertificateItemMapper);
@@ -106,7 +106,7 @@ describe("ItemMapperFactory unit tests", () => {
             const misconfiguredMapperFactory = new ItemMapperFactory([], () => new NullItemMapper());
 
             // When
-            const itemMapper = misconfiguredMapperFactory.getItemMapper("any", "any");
+            const itemMapper = misconfiguredMapperFactory.getItemMapper({companyType: "any", companyStatus: "any"});
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(NullItemMapper);

--- a/src/test/service/ItemMapperFactory.unit.test.ts
+++ b/src/test/service/ItemMapperFactory.unit.test.ts
@@ -4,6 +4,10 @@ import {ItemMapperFactory} from "../../service/ItemMapperFactory";
 import {OtherCertificateItemMapper} from "../../service/OtherCertificateItemMapper";
 import {LPCertificateItemMapper} from "../../service/LPCertificateItemMapper";
 import {LLPCertificateItemMapper} from "../../service/LLPCertificateItemMapper";
+import { CompanyStatus } from "../../model/CompanyStatus";
+import { LiquidatedOtherCertificateItemMapper } from "../../service/LiquidatedOtherCertificateItemMapper";
+import { ItemMapper } from "../../service/ItemMapper";
+import { NullItemMapper } from "../../service/NullItemMapper";
 
 describe("ItemMapperFactory unit tests", () => {
     const TRUE: string = "true";
@@ -11,15 +15,26 @@ describe("ItemMapperFactory unit tests", () => {
     describe("LP and LLP feature flags set to true", () => {
         let itemMapperFactory: ItemMapperFactory;
         beforeEach("instantiate ItemMapperFactory", () => {
-            itemMapperFactory = new ItemMapperFactory([[CompanyType.LIMITED_PARTNERSHIP, ()=>{return new LPCertificateItemMapper()}],
-            [CompanyType.LIMITED_LIABILITY_PARTNERSHIP, ()=>{return new LLPCertificateItemMapper()}]], () => {return new OtherCertificateItemMapper()})
+            itemMapperFactory = new ItemMapperFactory([
+                [CompanyType.LIMITED_PARTNERSHIP, new Map<string, () => ItemMapper>([
+                    ["default", () => {return new LPCertificateItemMapper()}]
+                ])],
+                [CompanyType.LIMITED_LIABILITY_PARTNERSHIP, new Map<string, () => ItemMapper>([
+                    ["default", () => {return new LLPCertificateItemMapper()}]
+                ])],
+                ["default", new Map<string, () => ItemMapper>([
+                    [CompanyStatus.LIQUIDATION, () => {return new LiquidatedOtherCertificateItemMapper()}],
+                    ["default", () => {return new OtherCertificateItemMapper()}]
+                ])]
+            ], () => {return new NullItemMapper()})
         })
         it("should correctly return OtherCertificateItemMapper for non LP & LLP companies", () => {
             // Given
             const companyType = "any";
+            const companyStatus = "active";
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType);
+            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(OtherCertificateItemMapper);
@@ -28,9 +43,10 @@ describe("ItemMapperFactory unit tests", () => {
         it("should correctly return OtherCertificateItemMapper for limited company type", () => {
             // Given
             const companyType = CompanyType.LIMITED_COMPANY;
+            const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType);
+            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(OtherCertificateItemMapper);
@@ -39,9 +55,10 @@ describe("ItemMapperFactory unit tests", () => {
         it("should correctly return LPCertificateItemMapper for limited partnership company type", () => {
             // Given
             const companyType = CompanyType.LIMITED_PARTNERSHIP;
+            const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType);
+            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LPCertificateItemMapper);
@@ -50,12 +67,26 @@ describe("ItemMapperFactory unit tests", () => {
         it("should correctly return LLPCertificateItemMapper for limited liability partnership company type", () => {
             // Given
             const companyType = CompanyType.LIMITED_LIABILITY_PARTNERSHIP;
+            const companyStatus = CompanyStatus.ACTIVE;
 
             // When
-            const itemMapper = itemMapperFactory.getItemMapper(companyType);
+            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
 
             // Then
             expect(itemMapper).to.be.an.instanceOf(LLPCertificateItemMapper);
         })
+
+        it("should correctly return LiquidatedOtherCertificateItemMapper for non LP & LLP companies in liquidation", () => {
+            // Given
+            const companyType = "any";
+            const companyStatus = "liquidation";
+
+            // When
+            const itemMapper = itemMapperFactory.getItemMapper(companyType, companyStatus);
+
+            // Then
+            expect(itemMapper).to.be.an.instanceOf(LiquidatedOtherCertificateItemMapper);
+        })
+
     })
 })

--- a/src/test/service/ItemMapperFactoryConfig.unit.test.ts
+++ b/src/test/service/ItemMapperFactoryConfig.unit.test.ts
@@ -19,11 +19,11 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns item mappers when LP & LLP feature flags are false and liquidation feature flag is true", () => {
@@ -34,11 +34,11 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
     });
 
     it("correctly returns item mappers when LP feature flag is true and liquidation feature flag is false", () => {
@@ -49,9 +49,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(LPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns item mappers when LLP feature flags is true and liquidation feature flag is false", () => {
@@ -62,9 +62,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LLPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(LLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns item mappers when LP, LLP and liquidation feature flags are true", () => {
@@ -75,10 +75,10 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LLPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedLLPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(LLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_LIABILITY_PARTNERSHIP, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(LiquidatedLLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_PARTNERSHIP, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(LPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.ACTIVE})).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper({companyType: CompanyType.LIMITED_COMPANY, companyStatus: CompanyStatus.LIQUIDATION})).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
     });
 })

--- a/src/test/service/ItemMapperFactoryConfig.unit.test.ts
+++ b/src/test/service/ItemMapperFactoryConfig.unit.test.ts
@@ -5,6 +5,8 @@ import {OtherCertificateItemMapper} from "../../service/OtherCertificateItemMapp
 import {LLPCertificateItemMapper} from "../../service/LLPCertificateItemMapper";
 import {LPCertificateItemMapper} from "../../service/LPCertificateItemMapper";
 import {FeatureFlags} from "../../config/FeatureFlags";
+import { CompanyStatus } from "../../model/CompanyStatus";
+import { LiquidatedOtherCertificateItemMapper } from "../../service/LiquidatedOtherCertificateItemMapper";
 
 
 describe("ItemMapperFactoryConfig unit tests", ()=>{
@@ -16,9 +18,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns LPCertificateItemMapper when LP Feature flags is true", () => {
@@ -29,9 +31,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP)).to.be.instanceOf(LPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns LLPCertificateItemMapper when LLP Feature flags is true", () => {
@@ -42,9 +44,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP)).to.be.instanceOf(LLPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
     it("correctly returns LPCertificateItemMapper & LLPCertificateItemMapper when LP & LLP Feature flags are true", () => {
@@ -55,8 +57,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP)).to.be.instanceOf(LLPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP)).to.be.instanceOf(LPCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper)
     });
 })

--- a/src/test/service/ItemMapperFactoryConfig.unit.test.ts
+++ b/src/test/service/ItemMapperFactoryConfig.unit.test.ts
@@ -7,25 +7,43 @@ import {LPCertificateItemMapper} from "../../service/LPCertificateItemMapper";
 import {FeatureFlags} from "../../config/FeatureFlags";
 import { CompanyStatus } from "../../model/CompanyStatus";
 import { LiquidatedOtherCertificateItemMapper } from "../../service/LiquidatedOtherCertificateItemMapper";
+import { LiquidatedLLPCertificateItemMapper } from "../../service/LiquidatedLLPCertificateItemMapper";
 
 
 describe("ItemMapperFactoryConfig unit tests", ()=>{
-    it("correctly returns OtherCertificateItemMapper when LP & LLP Feature flags are false", () => {
+    it("correctly returns item mappers when LP, LLP and liquidation feature flags are false", () => {
         // Given
-        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(false, false));
+        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(false, false, false));
 
         // When
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(OtherCertificateItemMapper);
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
-    it("correctly returns LPCertificateItemMapper when LP Feature flags is true", () => {
+    it("correctly returns item mappers when LP & LLP feature flags are false and liquidation feature flag is true", () => {
         // Given
-        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(true, false));
+        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(false, false, true));
+
+        // When
+        const itemMapperFactory = itemMapperFactoryConfig.getInstance();
+
+        // Then
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
+    });
+
+    it("correctly returns item mappers when LP feature flag is true and liquidation feature flag is false", () => {
+        // Given
+        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(true, false, false));
 
         // When
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
@@ -36,9 +54,9 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
-    it("correctly returns LLPCertificateItemMapper when LLP Feature flags is true", () => {
+    it("correctly returns item mappers when LLP feature flags is true and liquidation feature flag is false", () => {
         // Given
-        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(false, true));
+        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(false, true, false));
 
         // When
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
@@ -49,17 +67,18 @@ describe("ItemMapperFactoryConfig unit tests", ()=>{
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
     });
 
-    it("correctly returns LPCertificateItemMapper & LLPCertificateItemMapper when LP & LLP Feature flags are true", () => {
+    it("correctly returns item mappers when LP, LLP and liquidation feature flags are true", () => {
         // Given
-        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(true, true));
+        const itemMapperFactoryConfig = new ItemMapperFactoryConfig(new FeatureFlags(true, true, true));
 
         // When
         const itemMapperFactory = itemMapperFactoryConfig.getInstance();
 
         // Then
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LLPCertificateItemMapper);
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_LIABILITY_PARTNERSHIP, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedLLPCertificateItemMapper);
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_PARTNERSHIP, CompanyStatus.ACTIVE)).to.be.instanceOf(LPCertificateItemMapper);
         expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.ACTIVE)).to.be.instanceOf(OtherCertificateItemMapper);
-        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper)
+        expect(itemMapperFactory.getItemMapper(CompanyType.LIMITED_COMPANY, CompanyStatus.LIQUIDATION)).to.be.instanceOf(LiquidatedOtherCertificateItemMapper);
     });
 })

--- a/src/test/service/LLPCertificateItemMapper.unit.test.ts
+++ b/src/test/service/LLPCertificateItemMapper.unit.test.ts
@@ -1,188 +1,37 @@
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {expect} from "chai";
 import {LLPCertificateItemMapper} from "../../service/LLPCertificateItemMapper";
-import {DobType} from "../../model/DobType";
-import {MapUtil} from "../../service/MapUtil";
 
 describe("LLPCertificateItemMapper unit tests", () => {
 
     const llpCertificateItemMapper: LLPCertificateItemMapper = new LLPCertificateItemMapper;
 
-    describe("mapRegisteredOfficeAddress", () => {
-        const itemOptionsRegOfficeAddress = (addressRecordsType: string): CertificateItemOptions => {
-            return {
-                registeredOfficeAddressDetails: {
-                    includeAddressRecordsType: addressRecordsType
-                }
-            } as CertificateItemOptions;
-        };
+    describe("getOrdersDetailTable", () => {
+        it("transforms item into table", () => {
+            // given
+            const item = {
+                companyName: "ACME LTD",
+                companyNumber: "12345678",
+                itemOptions: {
+                    certificateType: "incorporation-with-all-name-changes",
+                    includeGoodStandingInformation: true,
+                    designatedMemberDetails: {
+                        includeBasicInformation: true
+                    },
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    memberDetails: {
+                        includeBasicInformation: true
+                    }
+                } as CertificateItemOptions
+            }
 
-        it("includeAddressRecordsType with a value of 'current' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current");
-            const result = llpCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address");
-        });
+            // when
+            const expected = llpCertificateItemMapper.getOrdersDetailTable(item)
 
-        it("includeAddressRecordsType with a value of 'current-and-previous' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-and-previous");
-            const result = llpCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the one previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'current-previous-and-prior' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-previous-and-prior");
-            const result = llpCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the two previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'all' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("all");
-            const result = llpCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("All current and previous addresses");
-        });
-
-        it("includeAddressRecordsType with a value of undefined returns correct mapped text", () => {
-            const itemOptions = {
-                registeredOfficeAddressDetails: {}
-            } as CertificateItemOptions;
-            const result = llpCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("No");
-        });
-    });
-
-    describe("Map designated members options", () => {
-        it("should correctly map designated members options when undefined", () => {
-            // Given
-            const itemOptions = {
-                designatedMemberDetails: {}
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapDesignatedMembersOptions(itemOptions.designatedMemberDetails);
-
-            // Then
-            expect(result).to.equal("No");
-        });
-
-        it("should correctly map designated members options when includeBasicInformation undefined", () => {
-            // Given
-            const itemOptions = {
-                designatedMemberDetails: {
-                    includeBasicInformation: undefined
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapDesignatedMembersOptions(itemOptions.designatedMemberDetails);
-
-            // Then
-            expect(result).to.equal("No");
-        });
-
-        it("should correctly map designated members options when includeBasicInformation is true and all other options are false", () => {
-            // Given
-            const itemOptions = {
-                designatedMemberDetails: {
-                    includeAddress: false,
-                    includeAppointmentDate: false,
-                    includeBasicInformation: true,
-                    includeCountryOfResidence: false,
-                    includeDobType: undefined
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapDesignatedMembersOptions(itemOptions.designatedMemberDetails);
-
-            // Then
-            expect(result).to.equal("Yes");
-        });
-
-        it("should correctly map designated members options when all options are true", () => {
-            // Given
-            const itemOptions = {
-                designatedMemberDetails: {
-                    includeAddress: true,
-                    includeAppointmentDate: true,
-                    includeBasicInformation: true,
-                    includeCountryOfResidence: true,
-                    includeDobType: DobType.PARTIAL
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapDesignatedMembersOptions(itemOptions.designatedMemberDetails);
-
-            // Then
-            expect(result).to.equal(MapUtil.mapToHtml(["Including designated members':", "Correspondence address", "Appointment date", "Country of residence", "Date of birth (month and year)"]));
-        });
-    });
-
-    describe("Map members options", () => {
-        it("should correctly map members options when undefined", () => {
-            // Given
-            const itemOptions = {
-                memberDetails: {}
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapMembersOptions(itemOptions.memberDetails);
-
-            // Then
-            expect(result).to.equal("No");
-        });
-
-        it("should correctly map members options when includeBasicInformation undefined", () => {
-            // Given
-            const itemOptions = {
-                memberDetails: {
-                    includeBasicInformation: undefined
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapMembersOptions(itemOptions.memberDetails);
-
-            // Then
-            expect(result).to.equal("No");
-        });
-
-        it("should correctly map members options when includeBasicInformation is true and all other options are false", () => {
-            // Given
-            const itemOptions = {
-                memberDetails: {
-                    includeAddress: false,
-                    includeAppointmentDate: false,
-                    includeBasicInformation: true,
-                    includeCountryOfResidence: false,
-                    includeDobType: undefined
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapMembersOptions(itemOptions.memberDetails);
-
-            // Then
-            expect(result).to.equal("Yes");
-        });
-
-        it("should correctly map members options when all options are true", () => {
-            // Given
-            const itemOptions = {
-                memberDetails: {
-                    includeAddress: true,
-                    includeAppointmentDate: true,
-                    includeBasicInformation: true,
-                    includeCountryOfResidence: true,
-                    includeDobType: DobType.PARTIAL
-                }
-            } as CertificateItemOptions;
-
-            // When
-            const result = llpCertificateItemMapper.mapMembersOptions(itemOptions.memberDetails);
-
-            // Then
-            expect(result).to.equal(MapUtil.mapToHtml(["Including members':", "Correspondence address", "Appointment date", "Country of residence", "Date of birth (month and year)"]));
-        });
-    });
+            // then
+            expect(expected.length).to.equal(7)
+        })
+    })
 });

--- a/src/test/service/LPCertificateItemMapper.unit.test.ts
+++ b/src/test/service/LPCertificateItemMapper.unit.test.ts
@@ -1,63 +1,38 @@
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {LPCertificateItemMapper} from "../../service/LPCertificateItemMapper";
 import {expect} from "chai";
-import {AddressRecordsType} from "../../model/AddressRecordsType";
 
 describe("mapPrincipalPlaceOfBusiness", () => {
 
     const lpCertificateItemMapper: LPCertificateItemMapper = new LPCertificateItemMapper;
 
-    const itemOptions = {
-        principalPlaceOfBusinessDetails: {
-            includeAddressRecordsType: "current"
-        }
-    } as CertificateItemOptions;
-
-    it("includeAddressRecordsType with a value of 'current' returns correct mapped text", () => {
-        const itemOptions = {
-            principalPlaceOfBusinessDetails: {
-                includeAddressRecordsType: AddressRecordsType.CURRENT
+    describe("getOrdersDetailTable", () => {
+        it("transforms item into table", () => {
+            // given
+            const item = {
+                companyName: "ACME LTD",
+                companyNumber: "12345678",
+                itemOptions: {
+                    certificateType: "incorporation-with-all-name-changes",
+                    includeGoodStandingInformation: true,
+                    principalPlaceOfBusinessDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    limitedPartnerDetails: {
+                        includeBasicInformation: true
+                    },
+                    generalPartnerDetails: {
+                        includeBasicInformation: true
+                    },
+                    includeGeneralNatureOfBusinessInformation: true
+                } as CertificateItemOptions
             }
-        } as CertificateItemOptions;
-        const result = lpCertificateItemMapper.mapPrincipalPlaceOfBusiness(itemOptions);
-        expect(result).to.equal("Current address");
-    });
 
-    it("includeAddressRecordsType with a value of 'current-and-previous' returns correct mapped text", () => {
-        const itemOptions = {
-            principalPlaceOfBusinessDetails: {
-                includeAddressRecordsType: AddressRecordsType.CURRENT_AND_PREVIOUS
-            }
-        } as CertificateItemOptions;
-        const result = lpCertificateItemMapper.mapPrincipalPlaceOfBusiness(itemOptions);
-        expect(result).to.equal("Current address and the one previous");
-    });
+            // when
+            const expected = lpCertificateItemMapper.getOrdersDetailTable(item)
 
-    it("includeAddressRecordsType with a value of 'current-previous-and-prior' returns correct mapped text", () => {
-        const itemOptions = {
-            principalPlaceOfBusinessDetails: {
-                includeAddressRecordsType: AddressRecordsType.CURRENT_PREVIOUS_AND_PRIOR
-            }
-        } as CertificateItemOptions;
-        const result = lpCertificateItemMapper.mapPrincipalPlaceOfBusiness(itemOptions);
-        expect(result).to.equal("Current address and the two previous");
-    });
-
-    it("includeAddressRecordsType with a value of 'all' returns correct mapped text", () => {
-        const itemOptions = {
-            principalPlaceOfBusinessDetails: {
-                includeAddressRecordsType: AddressRecordsType.ALL
-            }
-        } as CertificateItemOptions;
-        const result = lpCertificateItemMapper.mapPrincipalPlaceOfBusiness(itemOptions);
-        expect(result).to.equal("All current and previous addresses");
-    });
-
-    it("includeAddressRecordsType with a value of undefined returns correct mapped text", () => {
-        const itemOptions = {
-            principalPlaceOfBusinessDetails: {}
-        } as CertificateItemOptions;
-        const result = lpCertificateItemMapper.mapPrincipalPlaceOfBusiness(itemOptions);
-        expect(result).to.equal("No");
-    });
+            // then
+            expect(expected.length).to.equal(8)
+        })
+    })
 });

--- a/src/test/service/LiquidatedLLPCertificateItemMapper.unit.test.ts
+++ b/src/test/service/LiquidatedLLPCertificateItemMapper.unit.test.ts
@@ -1,10 +1,10 @@
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
-import {LiquidatedOtherCertificateItemMapper} from "../../service/LiquidatedOtherCertificateItemMapper";
 import {expect} from "chai";
+import { LiquidatedLLPCertificateItemMapper } from "../../service/LiquidatedLLPCertificateItemMapper";
 
-describe("Liquidated other certificate item mapper tests", () => {
+describe("Liquidated LLP certificate item mapper tests", () => {
 
-    const liquidatedOtherCertificateItemMapper: LiquidatedOtherCertificateItemMapper = new LiquidatedOtherCertificateItemMapper;
+    const liquidatedOtherCertificateItemMapper: LiquidatedLLPCertificateItemMapper = new LiquidatedLLPCertificateItemMapper;
 
     describe("getOrdersDetailTable", () => {
         it("transforms item into table", () => {
@@ -14,14 +14,13 @@ describe("Liquidated other certificate item mapper tests", () => {
                 companyNumber: "12345678",
                 itemOptions: {
                     certificateType: "incorporation-with-all-name-changes",
-                    directorDetails: {
+                    designatedMemberDetails: {
                         includeBasicInformation: true
                     },
-                    includeCompanyObjectsInformation: true,
                     registeredOfficeAddressDetails: {
                         includeAddressRecordsType: "current"
                     },
-                    secretaryDetails: {
+                    memberDetails: {
                         includeBasicInformation: true
                     },
                     liquidatorsDetails: {
@@ -34,8 +33,8 @@ describe("Liquidated other certificate item mapper tests", () => {
             const expected = liquidatedOtherCertificateItemMapper.getOrdersDetailTable(item)
 
             // then
-            expect(expected.length).to.equal(8)
-            expect(expected[7].key.text).to.equal("Liquidators' details")
+            expect(expected.length).to.equal(7)
+            expect(expected[6].key.text).to.equal("Liquidators' details")
         })
     })
 });

--- a/src/test/service/LiquidatedOtherCertificateItemMapper.unit.test.ts
+++ b/src/test/service/LiquidatedOtherCertificateItemMapper.unit.test.ts
@@ -1,0 +1,42 @@
+import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
+import {LiquidatedOtherCertificateItemMapper} from "../../service/LiquidatedOtherCertificateItemMapper";
+import {expect} from "chai";
+import {MapUtil} from "../../service/MapUtil";
+
+describe("Liquidated other certificate item mapper tests", () => {
+
+    const liquidatedOtherCertificateItemMapper: LiquidatedOtherCertificateItemMapper = new LiquidatedOtherCertificateItemMapper;
+
+    describe("getOrdersDetailTable", () => {
+        it("transforms item into table", () => {
+            // given
+            const item = {
+                companyName: "ACME LTD",
+                companyNumber: "12345678",
+                itemOptions: {
+                    certificateType: "incorporation-with-all-name-changes",
+                    directorDetails: {
+                        includeBasicInformation: true
+                    },
+                    includeCompanyObjectsInformation: true,
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    secretaryDetails: {
+                        includeBasicInformation: true
+                    },
+                    liquidatorsDetails: {
+                        includeBasicInformation: true
+                    }
+                } as CertificateItemOptions
+            }
+
+            // when
+            const expected = liquidatedOtherCertificateItemMapper.getOrdersDetailTable(item)
+
+            // then
+            expect(expected.length).to.equal(8)
+            expect(expected[7].key.text).to.equal("Liquidators' details")
+        })
+    })
+});

--- a/src/test/service/MapUtil.unit.test.ts
+++ b/src/test/service/MapUtil.unit.test.ts
@@ -131,4 +131,135 @@ describe("MapUtil unit tests", () => {
             expect(result).to.equal("All current and previous addresses");
         });
     });
+
+    describe("mapRegisteredOfficeAddress", () => {
+
+        const itemOptionsRegOfficeAddress = (addressRecordsType: string): CertificateItemOptions => {
+            return {
+                directorDetails: {
+                    includeBasicInformation: true
+                },
+                includeCompanyObjectsInformation: true,
+                includeGoodStandingInformation: true,
+                registeredOfficeAddressDetails: {
+                    includeAddressRecordsType: addressRecordsType
+                },
+                secretaryDetails: {
+                    includeBasicInformation: true
+                }
+            } as CertificateItemOptions;
+        };
+
+        it("includeAddressRecordsType with a value of 'current' returns correct mapped text", () => {
+            const itemOptions = itemOptionsRegOfficeAddress("current");
+            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
+            expect(result).to.equal("Current address");
+        });
+
+        it("includeAddressRecordsType with a value of 'current-and-previous' returns correct mapped text", () => {
+            const itemOptions = itemOptionsRegOfficeAddress("current-and-previous");
+            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
+            expect(result).to.equal("Current address and the one previous");
+        });
+
+        it("includeAddressRecordsType with a value of 'current-previous-and-prior' returns correct mapped text", () => {
+            const itemOptions = itemOptionsRegOfficeAddress("current-previous-and-prior");
+            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
+            expect(result).to.equal("Current address and the two previous");
+        });
+
+        it("includeAddressRecordsType with a value of 'all' returns correct mapped text", () => {
+            const itemOptions = itemOptionsRegOfficeAddress("all");
+            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
+            expect(result).to.equal("All current and previous addresses");
+        });
+
+        it("includeAddressRecordsType with a value of undefined returns correct mapped text", () => {
+            const itemOptions = {
+                directorDetails: {
+                    includeBasicInformation: true
+                },
+                includeCompanyObjectsInformation: true,
+                includeGoodStandingInformation: true,
+                registeredOfficeAddressDetails: {},
+                secretaryDetails: {
+                    includeBasicInformation: true
+                }
+            } as CertificateItemOptions;
+            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
+            expect(result).to.equal("No");
+        });
+    });
+
+    describe("determineDirectorOrSecretaryOptionsText", () => {
+        it("directorDetails with just basic information", () => {
+            const directorDetails = {
+                includeBasicInformation: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal("Yes");
+        });
+
+        it("directorDetails with basic information plus correspondence address", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeAddress: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Correspondence address"]));
+        });
+
+        it("directorDetails with basic information plus appointment date", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeAppointmentDate: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Appointment date"]));
+        });
+
+        it("directorDetails with basic information plus country of residence", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeCountryOfResidence: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Country of residence"]));
+        });
+
+        it("directorDetails with basic information plus nationality", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeNationality: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Nationality"]));
+        });
+
+        it("directorDetails with basic information plus occupation", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeOccupation: true
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Occupation"]));
+        });
+
+        it("directorDetails with basic information plus date of birth", () => {
+            const directorDetails = {
+                includeBasicInformation: true,
+                includeDobType: "partial"
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Date of birth (month and year)"]));
+        });
+
+        it("directorDetails include basic information is false", () => {
+            const directorDetails = {
+                includeBasicInformation: false
+            };
+            const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
+            expect(result).to.equal("No");
+        });
+    });
 });

--- a/src/test/service/MapUtil.unit.test.ts
+++ b/src/test/service/MapUtil.unit.test.ts
@@ -3,6 +3,7 @@ import {expect} from "chai";
 import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
 import { DISPATCH_DAYS } from "../../config/config";
 import {AddressRecordsType} from "../../model/AddressRecordsType";
+import { DobType } from "../../model/DobType";
 
 describe("MapUtil unit tests", () => {
     describe("determineItemOptionsSelectedText", () => {
@@ -132,65 +133,6 @@ describe("MapUtil unit tests", () => {
         });
     });
 
-    describe("mapRegisteredOfficeAddress", () => {
-
-        const itemOptionsRegOfficeAddress = (addressRecordsType: string): CertificateItemOptions => {
-            return {
-                directorDetails: {
-                    includeBasicInformation: true
-                },
-                includeCompanyObjectsInformation: true,
-                includeGoodStandingInformation: true,
-                registeredOfficeAddressDetails: {
-                    includeAddressRecordsType: addressRecordsType
-                },
-                secretaryDetails: {
-                    includeBasicInformation: true
-                }
-            } as CertificateItemOptions;
-        };
-
-        it("includeAddressRecordsType with a value of 'current' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current");
-            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address");
-        });
-
-        it("includeAddressRecordsType with a value of 'current-and-previous' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-and-previous");
-            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the one previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'current-previous-and-prior' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-previous-and-prior");
-            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the two previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'all' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("all");
-            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("All current and previous addresses");
-        });
-
-        it("includeAddressRecordsType with a value of undefined returns correct mapped text", () => {
-            const itemOptions = {
-                directorDetails: {
-                    includeBasicInformation: true
-                },
-                includeCompanyObjectsInformation: true,
-                includeGoodStandingInformation: true,
-                registeredOfficeAddressDetails: {},
-                secretaryDetails: {
-                    includeBasicInformation: true
-                }
-            } as CertificateItemOptions;
-            const result = MapUtil.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("No");
-        });
-    });
-
     describe("determineDirectorOrSecretaryOptionsText", () => {
         it("directorDetails with just basic information", () => {
             const directorDetails = {
@@ -260,6 +202,74 @@ describe("MapUtil unit tests", () => {
             };
             const result = MapUtil.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
             expect(result).to.equal("No");
+        });
+    });
+
+    describe("Map members options", () => {
+        it("should correctly map members options when undefined", () => {
+            // Given
+            const itemOptions = {
+                memberDetails: {}
+            } as CertificateItemOptions;
+
+            // When
+            const result = MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails);
+
+            // Then
+            expect(result).to.equal("No");
+        });
+
+        it("should correctly map members options when includeBasicInformation undefined", () => {
+            // Given
+            const itemOptions = {
+                memberDetails: {
+                    includeBasicInformation: undefined
+                }
+            } as CertificateItemOptions;
+
+            // When
+            const result = MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails);
+
+            // Then
+            expect(result).to.equal("No");
+        });
+
+        it("should correctly map members options when includeBasicInformation is true and all other options are false", () => {
+            // Given
+            const itemOptions = {
+                memberDetails: {
+                    includeAddress: false,
+                    includeAppointmentDate: false,
+                    includeBasicInformation: true,
+                    includeCountryOfResidence: false,
+                    includeDobType: undefined
+                }
+            } as CertificateItemOptions;
+
+            // When
+            const result = MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails);
+
+            // Then
+            expect(result).to.equal("Yes");
+        });
+
+        it("should correctly map members options when all options are true", () => {
+            // Given
+            const itemOptions = {
+                memberDetails: {
+                    includeAddress: true,
+                    includeAppointmentDate: true,
+                    includeBasicInformation: true,
+                    includeCountryOfResidence: true,
+                    includeDobType: DobType.PARTIAL
+                }
+            } as CertificateItemOptions;
+
+            // When
+            const result = MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails);
+
+            // Then
+            expect(result).to.equal(MapUtil.mapToHtml(["Including members':", "Correspondence address", "Appointment date", "Country of residence", "Date of birth (month and year)"]));
         });
     });
 });

--- a/src/test/service/NullItemMapper.unit.test.ts
+++ b/src/test/service/NullItemMapper.unit.test.ts
@@ -1,0 +1,25 @@
+import { CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { expect } from "chai";
+import { NullItemMapper } from "../../service/NullItemMapper";
+
+describe("NullItemMapper unit tests", () => {
+
+    const nullItemMapper = new NullItemMapper();
+
+    describe("getOrdersDetailTable", () => {
+        it("throws an error when rendering a table", () => {
+            // given
+            const item = {
+                companyName: "ACME LTD",
+                companyNumber: "12345678",
+                itemOptions: {} as CertificateItemOptions
+            };
+
+            // when
+            const execution = () => nullItemMapper.getOrdersDetailTable(item);
+
+            // then
+            expect(execution).to.throw("Mapper not found");
+        });
+    });
+});

--- a/src/test/service/OtherCertificateItemMapper.unit.test.ts
+++ b/src/test/service/OtherCertificateItemMapper.unit.test.ts
@@ -1,7 +1,6 @@
 import {CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/order";
 import {OtherCertificateItemMapper} from "../../service/OtherCertificateItemMapper";
 import {expect} from "chai";
-import {MapUtil} from "../../service/MapUtil";
 
 describe("Other certificate item mapper tests", () => {
 

--- a/src/test/service/OtherCertificateItemMapper.unit.test.ts
+++ b/src/test/service/OtherCertificateItemMapper.unit.test.ts
@@ -7,135 +7,33 @@ describe("Other certificate item mapper tests", () => {
 
     const otherCertificateItemMapper: OtherCertificateItemMapper = new OtherCertificateItemMapper;
 
-    describe("mapRegisteredOfficeAddress", () => {
+    describe("getOrdersDetailTable", () => {
+        it("transforms item into table", () => {
+            // given
+            const item = {
+                companyName: "ACME LTD",
+                companyNumber: "12345678",
+                itemOptions: {
+                    certificateType: "incorporation-with-all-name-changes",
+                    directorDetails: {
+                        includeBasicInformation: true
+                    },
+                    includeCompanyObjectsInformation: true,
+                    includeGoodStandingInformation: true,
+                    registeredOfficeAddressDetails: {
+                        includeAddressRecordsType: "current"
+                    },
+                    secretaryDetails: {
+                        includeBasicInformation: true
+                    }
+                } as CertificateItemOptions
+            }
 
-        const itemOptionsRegOfficeAddress = (addressRecordsType: string): CertificateItemOptions => {
-            return {
-                directorDetails: {
-                    includeBasicInformation: true
-                },
-                includeCompanyObjectsInformation: true,
-                includeGoodStandingInformation: true,
-                registeredOfficeAddressDetails: {
-                    includeAddressRecordsType: addressRecordsType
-                },
-                secretaryDetails: {
-                    includeBasicInformation: true
-                }
-            } as CertificateItemOptions;
-        };
+            // when
+            const expected = otherCertificateItemMapper.getOrdersDetailTable(item)
 
-        it("includeAddressRecordsType with a value of 'current' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current");
-            const result = otherCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address");
-        });
-
-        it("includeAddressRecordsType with a value of 'current-and-previous' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-and-previous");
-            const result = otherCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the one previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'current-previous-and-prior' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("current-previous-and-prior");
-            const result = otherCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("Current address and the two previous");
-        });
-
-        it("includeAddressRecordsType with a value of 'all' returns correct mapped text", () => {
-            const itemOptions = itemOptionsRegOfficeAddress("all");
-            const result = otherCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("All current and previous addresses");
-        });
-
-        it("includeAddressRecordsType with a value of undefined returns correct mapped text", () => {
-            const itemOptions = {
-                directorDetails: {
-                    includeBasicInformation: true
-                },
-                includeCompanyObjectsInformation: true,
-                includeGoodStandingInformation: true,
-                registeredOfficeAddressDetails: {},
-                secretaryDetails: {
-                    includeBasicInformation: true
-                }
-            } as CertificateItemOptions;
-            const result = otherCertificateItemMapper.mapRegisteredOfficeAddress(itemOptions);
-            expect(result).to.equal("No");
-        });
-    });
-
-
-    describe("determineDirectorOrSecretaryOptionsText", () => {
-        it("directorDetails with just basic information", () => {
-            const directorDetails = {
-                includeBasicInformation: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal("Yes");
-        });
-
-        it("directorDetails with basic information plus correspondence address", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeAddress: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Correspondence address"]));
-        });
-
-        it("directorDetails with basic information plus appointment date", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeAppointmentDate: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Appointment date"]));
-        });
-
-        it("directorDetails with basic information plus country of residence", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeCountryOfResidence: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Country of residence"]));
-        });
-
-        it("directorDetails with basic information plus nationality", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeNationality: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Nationality"]));
-        });
-
-        it("directorDetails with basic information plus occupation", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeOccupation: true
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Occupation"]));
-        });
-
-        it("directorDetails with basic information plus date of birth", () => {
-            const directorDetails = {
-                includeBasicInformation: true,
-                includeDobType: "partial"
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal(MapUtil.mapToHtml(["Including directors':", "", "Date of birth (month and year)"]));
-        });
-
-        it("directorDetails include basic information is false", () => {
-            const directorDetails = {
-                includeBasicInformation: false
-            };
-            const result = otherCertificateItemMapper.determineDirectorOrSecretaryOptionsText(directorDetails, "directors");
-            expect(result).to.equal("No");
-        });
-    });
+            // then
+            expect(expected.length).to.equal(8)
+        })
+    })
 });


### PR DESCRIPTION
* Mappers transform liquidated company certificate items into tables.
* Functionality toggleable with feature flag CERTS_FOR_LIQUIDATED_COMPANIES.

Resolves:
[BI-8850](https://companieshouse.atlassian.net/browse/BI-8850)