### PR TITLE
Add extra line break to LLP member details confirm

### DIFF
--- a/src/service/MapUtil.ts
+++ b/src/service/MapUtil.ts
@@ -153,6 +153,7 @@ export abstract class MapUtil {
 
         const membersMappings: string[] = [];
         membersMappings.push(heading);
+        membersMappings.push("");
 
         if (memberOptions.includeAddress) {
             membersMappings.push("Correspondence address");

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -141,8 +141,8 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#paymentReferenceValue").text()).to.equal(mockCertificateCheckoutResponse.paymentReference);
                     chai.expect($("#paymentTimeValue").text()).to.equal("16 December 2019 - 09:16:17");
                     chai.expect($("#registeredOfficeAddress").text().trim()).to.equal("Current address and the one previous");
-                    chai.expect($("#currentDesignatedMembersNames").html()).to.equal("Including designated members':<br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
-                    chai.expect($("#currentMembersNames").html()).to.equal("Including members':<br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
+                    chai.expect($("#currentDesignatedMembersNames").html()).to.equal("Including designated members':<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
+                    chai.expect($("#currentMembersNames").html()).to.equal("Including members':<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
                     chai.expect(getOrderStub).to.have.been.called;
                     chai.expect(resp.text).to.not.contain("Your document details");
                     done();

--- a/src/test/service/MapUtil.unit.test.ts
+++ b/src/test/service/MapUtil.unit.test.ts
@@ -269,7 +269,7 @@ describe("MapUtil unit tests", () => {
             const result = MapUtil.mapMembersOptions("Including members':", itemOptions.memberDetails);
 
             // Then
-            expect(result).to.equal(MapUtil.mapToHtml(["Including members':", "Correspondence address", "Appointment date", "Country of residence", "Date of birth (month and year)"]));
+            expect(result).to.equal(MapUtil.mapToHtml(["Including members':", "", "Correspondence address", "Appointment date", "Country of residence", "Date of birth (month and year)"]));
         });
     });
 });


### PR DESCRIPTION
* Make line spacing consistent in certififed certs for standard
  companies and LLPs' appointments'/members' details.