### PR TITLE
GCI-2127: Try fixing Sonar coverage config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.sources=src
 sonar.exclusions=**/bin/**, **/dist/**, **/coverage/**, **/node_modules/**, **/features/**
 sonar.tests=src/test
 sonar.test.inclusions=**/test/**.test.*
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
* Currently Sonar reports 0% code coverage for all existing and all new code for this project.
* [Documentation](https://docs.sonarcloud.io/enriching/test-coverage/javascript-typescript-test-coverage/) suggests we may be using a deprecated config parameter:

> The parameter `sonar.typescript.lcov.reportPaths` was formerly used for typescript coverage. This parameter has been deprecated. The parameter `sonar.javascript.lcov.reportPaths` is now used for both JavaScript and TypeScript.