### PR TITLE
GCI-2167 Create new delivery details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3150,6 +3150,15 @@
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.4.tgz",
       "integrity": "sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ=="
     },
+    "express-validator": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
+      "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "validator": "^13.7.0"
+      }
+    },
     "ext": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
@@ -8585,7 +8594,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-exhaust": {
       "version": "1.0.2",
@@ -9007,7 +9016,7 @@
     "to-no-case": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -9058,7 +9067,7 @@
     "to-snake-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
-      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
       "requires": {
         "to-space-case": "^1.0.0"
       }
@@ -9066,7 +9075,7 @@
     "to-space-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
       "requires": {
         "to-no-case": "^1.0.0"
       }
@@ -9544,6 +9553,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "value-or-function": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cookie-parser": "1.4.5",
     "escape-html": "1.0.3",
     "express": "4.17.1",
+    "express-validator": "^6.14.0",
     "govuk-frontend": "3.11.0",
     "http-errors": "^1.7.3",
     "ioredis": "4.16.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,10 +11,14 @@ import router from "./routers";
 import { PIWIK_SITE_ID, PIWIK_URL, COOKIE_SECRET, COOKIE_DOMAIN, CACHE_SERVER, APPLICATION_NAME, CHS_URL } from "./config/config";
 import * as pageUrls from "./model/page.urls";
 import errorHandlers from "./controllers/error.controller";
+import { ERROR_SUMMARY_TITLE } from "./model/error.messages";
 
 const app = express();
 
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
 app.use(cookieParser());
+
 
 // set some app variables from the environment
 app.set("port", process.env.PORT || "3000");
@@ -36,7 +40,7 @@ const env = nunjucks.configure([
 const cookieConfig: CookieConfig = { cookieName: "__SID", cookieSecret: COOKIE_SECRET, cookieDomain: COOKIE_DOMAIN };
 const sessionStore = new SessionStore(new Redis(`redis://${CACHE_SERVER}`));
 
-const PROTECTED_PATHS = [pageUrls.BASKET, pageUrls.ORDERS];
+const PROTECTED_PATHS = [pageUrls.BASKET, pageUrls.ORDERS, pageUrls.DELIVERY_DETAILS];
 app.use(PROTECTED_PATHS, createLoggerMiddleware(APPLICATION_NAME));
 app.use(PROTECTED_PATHS, SessionMiddleware(cookieConfig, sessionStore));
 app.use(PROTECTED_PATHS, authMiddleware);
@@ -49,6 +53,7 @@ env.addGlobal("CDN_URL", process.env.CDN_HOST);
 env.addGlobal("PIWIK_URL", PIWIK_URL);
 env.addGlobal("PIWIK_SITE_ID", PIWIK_SITE_ID);
 env.addGlobal("CHS_URL", CHS_URL);
+env.addGlobal("ERROR_SUMMARY_TITLE", ERROR_SUMMARY_TITLE);
 
 // serve static assets in development.
 // this will execute in production for now, but we will host these else where in the future.

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -1,5 +1,6 @@
 import { createApiClient } from "@companieshouse/api-sdk-node";
 import { Checkout as BasketCheckout, Basket, CheckoutResource } from "@companieshouse/api-sdk-node/dist/services/order/basket";
+import { BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import { CreatePaymentRequest, Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
 import Resource, { ApiResponse, ApiResult } from "@companieshouse/api-sdk-node/dist/services/resource";
@@ -19,6 +20,16 @@ export const getBasket = async (oAuth: string): Promise<Basket> => {
         throw createError(basketResource.httpStatusCode, basketResource.httpStatusCode.toString());
     }
     logger.info(`Get basket, status_code=${basketResource.httpStatusCode}`);
+    return basketResource.resource as Basket;
+};
+
+export const patchBasket = async (oAuth: string, basketPatchRequest: BasketPatchRequest): Promise<Basket> => {
+    const api = createApiClient(undefined, oAuth, API_URL);
+    const basketResource: Resource<Basket> = await api.basket.patchBasket(basketPatchRequest);
+    if (basketResource.httpStatusCode !== 200 && basketResource.httpStatusCode !== 201) {
+        throw createError(basketResource.httpStatusCode, basketResource.httpStatusCode.toString());
+    }
+    logger.info(`Patch basket, status_code=${basketResource.httpStatusCode}`);
     return basketResource.resource as Basket;
 };
 

--- a/src/controllers/delivery.details.controller.ts
+++ b/src/controllers/delivery.details.controller.ts
@@ -1,0 +1,104 @@
+import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
+import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import { getBasket, patchBasket } from "../client/api.client";
+import { BASKET } from "../model/page.urls";
+import { DELIVERY_DETAILS, EMAIL_OPTIONS } from "../model/template.paths";
+import { createLogger } from "ch-structured-logging";
+import { deliveryDetailsValidationRules, validate } from "../utils/delivery-details-validation";
+import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
+import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
+import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
+import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/session/keys/UserProfileKeys";
+import { APPLICATION_NAME } from "../config/config";
+const escape = require("escape-html");
+
+const FIRST_NAME_FIELD: string = "firstName";
+const LAST_NAME_FIELD: string = "lastName";
+const ADDRESS_LINE_ONE_FIELD: string = "addressLineOne";
+const ADDRESS_LINE_TWO_FIELD: string = "addressLineTwo";
+const ADDRESS_TOWN_FIELD: string = "addressTown";
+const ADDRESS_COUNTY_FIELD: string = "addressCounty";
+const ADDRESS_POSTCODE_FIELD: string = "addressPostcode";
+const ADDRESS_COUNTRY_FIELD: string = "addressCountry";
+const PAGE_TITLE: string = "Delivery details - Order a certificate - GOV.UK";
+
+const logger = createLogger(APPLICATION_NAME);
+
+export const render = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+        const signInInfo = req.session?.data[SessionKey.SignInInfo];
+        const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
+        const basket: Basket = await getBasket(accessToken);
+        return res.render(DELIVERY_DETAILS, {
+            firstName: basket.deliveryDetails?.forename,
+            lastName: basket.deliveryDetails?.surname,
+            addressLineOne: basket.deliveryDetails?.addressLine1,
+            addressLineTwo: basket.deliveryDetails?.addressLine2,
+            addressCountry: basket.deliveryDetails?.country,
+            addressTown: basket.deliveryDetails?.locality,
+            addressPoBox: basket.deliveryDetails?.poBox,
+            addressPostcode: basket.deliveryDetails?.postalCode,
+            addressCounty: basket.deliveryDetails?.region,
+            templateName: DELIVERY_DETAILS,
+            pageTitleText: PAGE_TITLE,
+            backLink: BASKET
+        });
+    } catch (err) {
+        logger.error(`${err}`);
+        next(err);
+    }
+};
+
+export const route = async (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    const errorList = validate(errors);
+    const firstName: string = req.body[FIRST_NAME_FIELD];
+    const lastName: string = req.body[LAST_NAME_FIELD];
+    const addressLineOne: string = req.body[ADDRESS_LINE_ONE_FIELD];
+    const addressLineTwo: string = req.body[ADDRESS_LINE_TWO_FIELD];
+    const addressTown: string = req.body[ADDRESS_TOWN_FIELD];
+    const addressCounty: string = req.body[ADDRESS_COUNTY_FIELD];
+    const addressPostcode: string = req.body[ADDRESS_POSTCODE_FIELD];
+    const addressCountry: string = req.body[ADDRESS_COUNTRY_FIELD];
+
+    const signInInfo = req.session?.data[SessionKey.SignInInfo];
+    const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
+    const userId = signInInfo?.[SignInInfoKeys.UserProfile]?.[UserProfileKeys.UserId];
+    if (!errors.isEmpty()) {
+        return res.render(DELIVERY_DETAILS, {
+            ...errorList,
+            addressCountry,
+            addressCounty,
+            addressLineOne,
+            addressLineTwo,
+            addressPostcode,
+            addressTown,
+            firstName,
+            lastName,
+            pageTitle: PAGE_TITLE,
+            templateName: (DELIVERY_DETAILS),
+            backLink: BASKET
+        });
+    }
+    try {
+        const basketDeliveryDetails: BasketPatchRequest = {
+            deliveryDetails: {
+                addressLine1: addressLineOne,
+                addressLine2: addressLineTwo || null,
+                country: addressCountry,
+                forename: firstName,
+                locality: addressTown,
+                postalCode: addressPostcode || null,
+                region: addressCounty || null,
+                surname: lastName
+            }
+        };
+        await patchBasket(accessToken, basketDeliveryDetails);
+        logger.info(`Patched basket with delivery details, certificate_id=${req.params.certificateId}, user_id=${userId}`);
+        return res.redirect(BASKET);
+    } catch (err) {
+        logger.error(`${err}`);
+        return next(err);
+    }
+};

--- a/src/controllers/delivery.details.controller.ts
+++ b/src/controllers/delivery.details.controller.ts
@@ -3,7 +3,7 @@ import { validationResult } from "express-validator";
 import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 import { getBasket, patchBasket } from "../client/api.client";
 import { BASKET } from "../model/page.urls";
-import { DELIVERY_DETAILS, EMAIL_OPTIONS } from "../model/template.paths";
+import { DELIVERY_DETAILS } from "../model/template.paths";
 import { createLogger } from "ch-structured-logging";
 import { deliveryDetailsValidationRules, validate } from "../utils/delivery-details-validation";
 import { Session } from "@companieshouse/node-session-handler/lib/session/model/Session";
@@ -76,7 +76,7 @@ export const route = async (req: Request, res: Response, next: NextFunction) => 
             addressTown,
             firstName,
             lastName,
-            pageTitle: PAGE_TITLE,
+            pageTitleText: PAGE_TITLE,
             templateName: (DELIVERY_DETAILS),
             backLink: BASKET
         });
@@ -102,3 +102,5 @@ export const route = async (req: Request, res: Response, next: NextFunction) => 
         return next(err);
     }
 };
+
+export default [...deliveryDetailsValidationRules, route];

--- a/src/model/error.messages.ts
+++ b/src/model/error.messages.ts
@@ -1,0 +1,35 @@
+export const ERROR_SUMMARY_TITLE: string = "There is a problem";
+
+export const GOOD_STANDING_OPTION_NOT_SELECTED: string =
+    "Select if you want good standing information on the certificate";
+export const REGISTERED_OFFICE_OPTION_NOT_SELECTED: string =
+    "Select which registered office address you need on your certificate";
+export const PRINCIPAL_PLACE_OPTION_NOT_SELECTED: string =
+    "Select which principal place of business information you need on your certificate";
+export const ORDERS_DETAILS_FIRST_NAME_EMPTY: string = "Enter your first name";
+export const ORDERS_DETAILS_LAST_NAME_EMPTY: string = "Enter your last name";
+export const ORDER_DETAILS_FIRST_NAME_MAX_LENGTH: string = "First name must be 32 characters or fewer";
+export const ORDER_DETAILS_LAST_NAME_MAX_LENGTH: string = "Last name must be 32 characters or fewer";
+export const FIRST_NAME_INVALID_CHARACTERS: string = "First name cannot include ";
+export const LAST_NAME_INVALID_CHARACTERS: string = "Last name cannot include ";
+export const COLLECTION_OFFICE: string = "Select the Companies House office you want to collect your certificate from";
+export const ADDRESS_LINE_ONE_EMPTY: string = "Enter a building and street";
+export const ADDRESS_LINE_ONE_INVALID_CHARACTERS: string = "Address line 1 cannot include ";
+export const ADDRESS_LINE_ONE_MAX_LENGTH: string = "Address line 1 must be 50 characters or fewer";
+export const ADDRESS_LINE_TWO_INVALID_CHARACTERS: string = "Address line 2 cannot include ";
+export const ADDRESS_LINE_TWO_MAX_LENGTH: string = "Address line 2 must be 50 characters or fewer";
+export const ADDRESS_TOWN_EMPTY: string = "Enter a town or city";
+export const ADDRESS_TOWN_INVALID_CHARACTERS: string = "Town or city cannot include ";
+export const ADDRESS_TOWN_MAX_LENGTH: string = "Town or city must be 50 characters or fewer";
+export const ADDRESS_COUNTY_INVALID_CHARACTERS: string = "County cannot include ";
+export const ADDRESS_COUNTY_MAX_LENGTH: string = "County must be 50 characters or fewer";
+export const ADDRESS_COUNTY_EMPTY: string = "Enter a county";
+export const ADDRESS_POSTCODE_EMPTY: string = "Enter a postcode";
+export const ADDRESS_POSTCODE_INVALID_CHARACTERS: string = "Postcode cannot include ";
+export const ADDRESS_POSTCODE_MAX_LENGTH: string = "Postcode must be 15 characters or fewer";
+export const ADDRESS_COUNTRY_INVALID_CHARACTERS: string = "Country cannot include ";
+export const ADDRESS_COUNTRY_MAX_LENGTH: string = "Country must be 50 characters or fewer";
+export const ADDRESS_COUNTY_AND_POSTCODE_EMPTY: string = "Enter a county or postcode";
+export const ADDRESS_COUNTRY_EMPTY: string = "Enter a country";
+export const DELIVERY_OPTION_SELECTION: string = "Select a delivery option";
+export const EMAIL_OPTION_SELECTION: string = "Select ‘yes’ if you would like an email copy of the certificate";

--- a/src/model/govuk.error.data.ts
+++ b/src/model/govuk.error.data.ts
@@ -1,0 +1,21 @@
+// Used by the Gov.uk nunjucks components to extract
+// validation error messages
+
+export interface GovUkErrorData {
+  href: string;
+  flag: boolean;
+  text: string;
+  type: string;
+}
+
+export const createGovUkErrorData = (errorText: string,
+    errorHref: string,
+    errorFlag: boolean,
+    errorType: string): GovUkErrorData => {
+    return {
+        flag: errorFlag,
+        href: errorHref,
+        text: errorText,
+        type: errorType
+    };
+};

--- a/src/model/page.urls.ts
+++ b/src/model/page.urls.ts
@@ -2,6 +2,7 @@ export const ORDERS: string = "/orders";
 // ORDER_COMPLETE is currently a dummy url
 export const ORDER_COMPLETE: string = "/orders/:orderId/confirmation";
 export const BASKET: string = "/basket";
+export const DELIVERY_DETAILS: string = "/delivery-details";
 
 export const replaceOrderId = (uri: string, orderId: string) => {
     return uri.replace(":orderId", orderId);

--- a/src/model/template.paths.ts
+++ b/src/model/template.paths.ts
@@ -3,3 +3,5 @@ export const ORDER_COMPLETE: string = "order-complete";
 export const ERROR: string = "error";
 export const ERROR_START_AGAIN: string = "error-start-again";
 export const ERROR_NOT_FOUND: string = "error-not-found";
+export const DELIVERY_DETAILS: string = "delivery-details";
+export const EMAIL_OPTIONS: string = "email-options";

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -4,6 +4,7 @@ import * as pageUrls from "../model/page.urls";
 import * as templatePaths from "../model/template.paths";
 import { render as renderBasket } from "../controllers/basket.controller";
 import { render as renderOrderConfirmation } from "../controllers/order.confirmation.controller";
+import { render as renderDeliveryDetails, route as routeDeliveryDetails } from "../controllers/delivery.details.controller";
 
 const renderTemplate = (template: string) => (req: Request, res: Response, next: NextFunction) => {
     return res.render(template, { templateName: template });
@@ -14,5 +15,8 @@ const router: Router = Router();
 router.get(pageUrls.ORDERS, renderTemplate(templatePaths.BLANK));
 router.get(pageUrls.ORDER_COMPLETE, renderOrderConfirmation);
 router.get(pageUrls.BASKET, renderBasket);
+
+router.get(pageUrls.DELIVERY_DETAILS, renderDeliveryDetails);
+router.post(pageUrls.DELIVERY_DETAILS, routeDeliveryDetails);
 
 export default router;

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -4,7 +4,7 @@ import * as pageUrls from "../model/page.urls";
 import * as templatePaths from "../model/template.paths";
 import { render as renderBasket } from "../controllers/basket.controller";
 import { render as renderOrderConfirmation } from "../controllers/order.confirmation.controller";
-import { render as renderDeliveryDetails, route as routeDeliveryDetails } from "../controllers/delivery.details.controller";
+import deliveryDetailsController, { render as renderDeliveryDetails } from "../controllers/delivery.details.controller";
 
 const renderTemplate = (template: string) => (req: Request, res: Response, next: NextFunction) => {
     return res.render(template, { templateName: template });
@@ -17,6 +17,6 @@ router.get(pageUrls.ORDER_COMPLETE, renderOrderConfirmation);
 router.get(pageUrls.BASKET, renderBasket);
 
 router.get(pageUrls.DELIVERY_DETAILS, renderDeliveryDetails);
-router.post(pageUrls.DELIVERY_DETAILS, routeDeliveryDetails);
+router.post(pageUrls.DELIVERY_DETAILS, deliveryDetailsController);
 
 export default router;

--- a/src/test/client/api.client.unit.test.ts
+++ b/src/test/client/api.client.unit.test.ts
@@ -3,14 +3,46 @@ import chai from "chai";
 import BasketService from "@companieshouse/api-sdk-node/dist/services/order/basket/service";
 import PaymentService from "@companieshouse/api-sdk-node/dist/services/payment/service";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/basket";
-import { ApiResponse, ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import Resource, { ApiResponse, ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { success, failure } from "@companieshouse/api-sdk-node/dist/services/result";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
+import { Basket, BasketPatchRequest } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
 
-import { checkoutBasket, createPayment } from "../../client/api.client";
+import { checkoutBasket, createPayment, patchBasket } from "../../client/api.client";
 const O_AUTH_TOKEN = "oauth";
 
 const sandbox = sinon.createSandbox();
+
+const dummyBasketSDKResponse: Resource<Basket> = {
+    httpStatusCode: 200,
+    resource: {
+        deliveryDetails: {
+            addressLine1: "117 kings road",
+            addressLine2: "canton",
+            country: "wales",
+            forename: "John",
+            locality: "Cardiff",
+            poBox: "po box",
+            postalCode: "CF5 3NB",
+            region: "Glamorgan",
+            surname: "Smith"
+        }
+    }
+};
+
+const basketPatchRequest: BasketPatchRequest = {
+    deliveryDetails: {
+        addressLine1: "117 kings road",
+        addressLine2: "canton",
+        country: "wales",
+        forename: "John",
+        locality: "Cardiff",
+        poBox: "po box",
+        postalCode: "CF5 3NB",
+        region: "Glamorgan",
+        surname: "Smith"
+    }
+};
 
 describe("api.client", () => {
     afterEach(() => {
@@ -69,6 +101,13 @@ describe("api.client", () => {
             sandbox.stub(PaymentService.prototype, "createPaymentWithFullUrl").returns(Promise.resolve(failure(checkoutServiceResponse)));
 
             return chai.expect(checkoutBasket(O_AUTH_TOKEN)).to.be.rejected;
+        });
+    });
+    describe("patchBasket", () => {
+        it("returns the Basket details following PATCH basket", async () => {
+            sandbox.stub(BasketService.prototype, "patchBasket").returns(Promise.resolve(dummyBasketSDKResponse));
+            const patchBasketDetails = await patchBasket("oauth", basketPatchRequest);
+            chai.expect(patchBasketDetails).to.equal(dummyBasketSDKResponse.resource);
         });
     });
 });

--- a/src/test/controllers/delivery.details.controller.integration.test.ts
+++ b/src/test/controllers/delivery.details.controller.integration.test.ts
@@ -1,0 +1,216 @@
+import chai from "chai";
+import sinon from "sinon";
+import ioredis from "ioredis";
+import cheerio from "cheerio";
+import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket/types";
+import * as apiClient from "../../../src/client/api.client";
+import * as errorMessages from "../../../src/model/error.messages";
+import { SIGNED_IN_COOKIE, signedInSession } from "../__mocks__/redis.mocks";
+
+const ENTER_YOUR_FIRST_NAME_NOT_INPUT = "Enter your first name";
+const ENTER_YOUR_LAST_NAME_NOT_INPUT = "Enter your last name";
+const ENTER_BUILDING_AND_STREET_LINE_ONE = "Enter a building and street";
+const FIRST_NAME_INVALID_CHARACTER_ERROR = "First name cannot include";
+const LAST_NAME_INVALID_CHARACTER_ERROR = "Last name cannot include";
+const ADDRESS_LINE_ONE_INVALID_CHARACTERS_ERROR: string = "Address line 1 cannot include ";
+const ADDRESS_LINE_TWO_INVALID_CHARACTERS_ERROR: string = "Address line 2 cannot include ";
+const ADDRESS_TOWN_INVALID_CHARACTERS_ERROR: string = "Town or city cannot include ";
+const ADDRESS_COUNTY_INVALID_CHARACTERS_ERROR: string = "County cannot include ";
+const ADDRESS_POSTCODE_INVALID_CHARACTERS_ERROR: string = "Postcode cannot include ";
+const ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR: string = "Country cannot include ";
+const INVALID_CHARACTER = "|";
+const CHARACTER_LENGTH_TEXT_50 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const POSTCODE: string = "CX14 1BX";
+const COUNTY: string = "county";
+const DELIVERY_DETAILS_URL = "/basket";
+
+const sandbox = sinon.createSandbox();
+let testApp = null;
+let getBasketStub;
+let patchBasketStub;
+
+describe("certificate.delivery.details.controller", () => {
+    beforeEach((done) => {
+        sandbox.stub(ioredis.prototype, "connect").returns(Promise.resolve());
+        sandbox.stub(ioredis.prototype, "get").returns(Promise.resolve(signedInSession));
+        testApp = require("../../../src/app").default;
+        done();
+    });
+
+    afterEach(() => {
+        sandbox.reset();
+        sandbox.restore();
+    });
+
+    describe("delivery details url test", () => {
+        it("renders the delivery details web page", async () => {
+            const basketDetails = {
+                deliveryDetails: {
+                    addressLine1: "117 kings road",
+                    addressLine2: "pontcanna",
+                    country: "wales",
+                    locality: "canton",
+                    postalCode: "cf5 4xb",
+                    region: "glamorgan"
+                }
+            } as Basket;
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_DETAILS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect(resp.text).to.contain("What are the delivery details?");
+        });
+    });
+
+    describe("delivery details validation test", () => {
+        it("should receive error message instructing user to input required fields", async () => {
+            const res = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(res.status).to.equal(200);
+            chai.expect(res.text).to.contain(ENTER_YOUR_FIRST_NAME_NOT_INPUT);
+            chai.expect(res.text).to.contain(ENTER_YOUR_LAST_NAME_NOT_INPUT);
+            chai.expect(res.text).to.contain(ENTER_BUILDING_AND_STREET_LINE_ONE);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTY_AND_POSTCODE_EMPTY);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTRY_EMPTY);
+        });
+    });
+
+    describe("delivery details validation", () => {
+        it("should receive error message when entering invalid characters in all fields", async () => {
+            const res = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .set("Accept", "application/json")
+                .send({
+                    addressCountry: INVALID_CHARACTER,
+                    addressCounty: INVALID_CHARACTER,
+                    addressLineOne: INVALID_CHARACTER,
+                    addressLineTwo: INVALID_CHARACTER,
+                    addressPostcode: INVALID_CHARACTER,
+                    addressTown: INVALID_CHARACTER,
+                    firstName: INVALID_CHARACTER,
+                    lastName: INVALID_CHARACTER
+                })
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(res.status).to.equal(200);
+            chai.expect(res.text).to.contain(FIRST_NAME_INVALID_CHARACTER_ERROR);
+            chai.expect(res.text).to.contain(LAST_NAME_INVALID_CHARACTER_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_LINE_ONE_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_LINE_TWO_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_TOWN_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_COUNTY_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_POSTCODE_INVALID_CHARACTERS_ERROR);
+            chai.expect(res.text).to.contain(ADDRESS_COUNTRY_INVALID_CHARACTERS_ERROR);
+        });
+
+        it("should receive error messages requesting less than allowed character length in input fields", async () => {
+            const res = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .send({
+                    addressCountry: CHARACTER_LENGTH_TEXT_50,
+                    addressCounty: CHARACTER_LENGTH_TEXT_50,
+                    addressLineOne: CHARACTER_LENGTH_TEXT_50,
+                    addressLineTwo: CHARACTER_LENGTH_TEXT_50,
+                    addressPostcode: CHARACTER_LENGTH_TEXT_50,
+                    addressTown: CHARACTER_LENGTH_TEXT_50,
+                    firstName: CHARACTER_LENGTH_TEXT_50,
+                    lastName: CHARACTER_LENGTH_TEXT_50
+                })
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(res.status).to.equal(200);
+            chai.expect(res.text).to.contain(errorMessages.ORDER_DETAILS_FIRST_NAME_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ORDER_DETAILS_LAST_NAME_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_LINE_ONE_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_LINE_TWO_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_TOWN_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTY_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_POSTCODE_MAX_LENGTH);
+            chai.expect(res.text).to.contain(errorMessages.ADDRESS_COUNTRY_MAX_LENGTH);
+        });
+
+        it("should not receive Postcode or county error message when postcode is input", async () => {
+            const res = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .send({
+                    addressPostcode: POSTCODE
+                })
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(res.status).to.equal(200);
+            chai.expect(res.text).not.to.contain(errorMessages.ADDRESS_COUNTY_AND_POSTCODE_EMPTY);
+        });
+
+        it("should not receive Postcode or county error message when county is input", async () => {
+            const res = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .send({
+                    addressCounty: COUNTY
+                })
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(res.status).to.equal(200);
+            chai.expect(res.text).not.to.contain(errorMessages.ADDRESS_COUNTY_AND_POSTCODE_EMPTY);
+        });
+    });
+
+    describe("delivery details patch to Basket", () => {
+        it("redirects the user to the check details page", async () => {
+            const basketDetails = {} as Basket;
+            patchBasketStub = sandbox.stub(apiClient, "patchBasket").returns(Promise.resolve(basketDetails));
+
+            const resp = await chai.request(testApp)
+                .post(DELIVERY_DETAILS_URL)
+                .send({
+                    addressCountry: "Wales",
+                    addressCounty: "glamorgan",
+                    addressLineOne: "117 kings road",
+                    addressLineTwo: "Pontcanna",
+                    addressPostcode: "CF11 9VE",
+                    addressTown: "CARDIFF",
+                    firstName: "JOHN",
+                    lastName: "SMITH"
+                })
+                .redirects(0)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            chai.expect(resp.status).to.equal(302);
+            chai.expect(resp.text).to.contain("Found. Redirecting to check-details");
+        });
+    });
+
+    describe("delivery details back button", () => {
+        it("back button takes the user to the email options page if they selected same-day delivery", async () => {
+            const basketDetails = {} as Basket;
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_DETAILS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.equal("/basket");
+        });
+
+        it("back button takes the user to the delivery options page if they selected standard delivery", async () => {
+            const basketDetails = {} as Basket;
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketDetails));
+
+            const resp = await chai.request(testApp)
+                .get(DELIVERY_DETAILS_URL)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
+
+            const $ = cheerio.load(resp.text);
+
+            chai.expect(resp.status).to.equal(200);
+            chai.expect($(".govuk-back-link").attr("href")).to.equal("/basket");
+        });
+    });
+});

--- a/src/test/controllers/delivery.details.controller.integration.test.ts
+++ b/src/test/controllers/delivery.details.controller.integration.test.ts
@@ -22,7 +22,7 @@ const INVALID_CHARACTER = "|";
 const CHARACTER_LENGTH_TEXT_50 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const POSTCODE: string = "CX14 1BX";
 const COUNTY: string = "county";
-const DELIVERY_DETAILS_URL = "/basket";
+const DELIVERY_DETAILS_URL = "/delivery-details";
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
@@ -180,7 +180,7 @@ describe("certificate.delivery.details.controller", () => {
                 .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`]);
 
             chai.expect(resp.status).to.equal(302);
-            chai.expect(resp.text).to.contain("Found. Redirecting to check-details");
+            chai.expect(resp.text).to.contain("Found. Redirecting to /basket");
         });
     });
 

--- a/src/test/utils/char.set.unit.test.ts
+++ b/src/test/utils/char.set.unit.test.ts
@@ -1,0 +1,17 @@
+import chai from "chai";
+import { validateCharSet } from "../../utils/char-set";
+
+const DUMMY_INVALID_NAME = "aaaa|";
+const DUMMY_VALID_NAME = "bbbbbbbb";
+
+describe("char.set.unit", () => {
+    it("should return the invalid character if one is found", () => {
+        const validatedCharSet = validateCharSet(DUMMY_INVALID_NAME);
+        chai.expect(validatedCharSet).to.equal("|");
+    });
+
+    it("should return undefined if no invalid characters are found", () => {
+        const validatedCharSet = validateCharSet(DUMMY_VALID_NAME);
+        chai.expect(validatedCharSet).to.be.undefined;
+    });
+});

--- a/src/utils/char-set.ts
+++ b/src/utils/char-set.ts
@@ -1,0 +1,5 @@
+const restricted = "AÀÁÂÃÄÅĀĂĄǺaàáâãäåāăąǻÆǼæǽBbCcçćĉċčDÞĎĐdþďđEÈÉÊËĒĔĖĘĚeèéêëēĕėęěFfGĜĞĠĢgĝğġģHĤĦhĥħIÌÍÎÏĨĪĬĮİiìíîïĩīĭįJĴjĵKĶkķLĹĻĽĿŁlĺļľŀłMmNÑŃŅŇŊnñńņňŋOÒÓÔÕÖØŌŎŐǾoòóôõöøōŏőǿŒœPpQqRŔŖŘrŕŗřSŚŜŞŠsśŝşšTŢŤŦtţťŧUÙÚÛÜŨŪŬŮŰŲuùúûüũūŭůűųVvWŴẀẂẄwŵẁẃẅXxYỲÝŶŸyỳýŷÿZŹŻŽzźżž&@£$€¥*=#%+‘ʼ'()/\\[]{}<>!«»?“ˮ\"0123456789.,:;–- \r\n";
+
+export const validateCharSet = (input) => {
+    return input.split("").find((ch: string) => restricted.indexOf(ch) === -1);
+};

--- a/src/utils/delivery-details-validation.ts
+++ b/src/utils/delivery-details-validation.ts
@@ -1,0 +1,161 @@
+import { check } from "express-validator";
+import * as errorMessages from "../model/error.messages";
+import { validateCharSet } from "../utils/char-set";
+import { createGovUkErrorData, GovUkErrorData } from "../model/govuk.error.data";
+
+const FIRST_NAME_FIELD: string = "firstName";
+const LAST_NAME_FIELD: string = "lastName";
+const ADDRESS_LINE_ONE_FIELD: string = "addressLineOne";
+const ADDRESS_LINE_TWO_FIELD: string = "addressLineTwo";
+const ADDRESS_TOWN_FIELD: string = "addressTown";
+const ADDRESS_COUNTY_FIELD: string = "addressCounty";
+const ADDRESS_POSTCODE_FIELD: string = "addressPostcode";
+const ADDRESS_COUNTRY_FIELD: string = "addressCountry";
+
+export const deliveryDetailsValidationRules =
+    [
+        check(FIRST_NAME_FIELD)
+            .not().isEmpty().withMessage(errorMessages.ORDERS_DETAILS_FIRST_NAME_EMPTY)
+            .isLength({ max: 32 }).withMessage(errorMessages.ORDER_DETAILS_FIRST_NAME_MAX_LENGTH)
+            .custom((firstName, { req }) => {
+                const invalidChar = validateCharSet(req.body[FIRST_NAME_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.FIRST_NAME_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(LAST_NAME_FIELD)
+            .not().isEmpty().withMessage(errorMessages.ORDERS_DETAILS_LAST_NAME_EMPTY)
+            .isLength({ max: 32 }).withMessage(errorMessages.ORDER_DETAILS_LAST_NAME_MAX_LENGTH)
+            .custom((lastName, { req }) => {
+                const invalidChar = validateCharSet(req.body[LAST_NAME_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.LAST_NAME_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(ADDRESS_LINE_ONE_FIELD)
+            .not().isEmpty().withMessage(errorMessages.ADDRESS_LINE_ONE_EMPTY)
+            .isLength({ max: 50 }).withMessage(errorMessages.ADDRESS_LINE_ONE_MAX_LENGTH)
+            .custom((addressLineOne, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_LINE_ONE_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_LINE_ONE_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(ADDRESS_LINE_TWO_FIELD)
+            .isLength({ max: 50 }).withMessage(errorMessages.ADDRESS_LINE_TWO_MAX_LENGTH)
+            .custom((addressLineTwo, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_LINE_TWO_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_LINE_TWO_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(ADDRESS_TOWN_FIELD)
+            .not().isEmpty().withMessage(errorMessages.ADDRESS_TOWN_EMPTY)
+            .isLength({ max: 50 }).withMessage(errorMessages.ADDRESS_TOWN_MAX_LENGTH)
+            .custom((addressTown, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_TOWN_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_TOWN_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+
+        check(ADDRESS_COUNTY_FIELD)
+            .custom((addressCounty, { req }) => {
+                const addressPostcodeValue = req.body[ADDRESS_POSTCODE_FIELD];
+                if (!addressPostcodeValue && !addressCounty) {
+                    throw Error(errorMessages.ADDRESS_COUNTY_AND_POSTCODE_EMPTY);
+                }
+                return true;
+            }),
+        check(ADDRESS_COUNTY_FIELD)
+            .isLength({ max: 50 }).withMessage(errorMessages.ADDRESS_COUNTY_MAX_LENGTH)
+            .custom((addressCounty, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_COUNTY_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_COUNTY_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(ADDRESS_POSTCODE_FIELD)
+            .isLength({ max: 15 }).withMessage(errorMessages.ADDRESS_POSTCODE_MAX_LENGTH)
+            .custom((addressPostcode, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_POSTCODE_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_POSTCODE_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            }),
+        check(ADDRESS_COUNTRY_FIELD)
+            .not().isEmpty().withMessage(errorMessages.ADDRESS_COUNTRY_EMPTY)
+            .isLength({ max: 50 }).withMessage(errorMessages.ADDRESS_COUNTRY_MAX_LENGTH)
+            .custom((addressCountry, { req }) => {
+                const invalidChar = validateCharSet(req.body[ADDRESS_COUNTRY_FIELD]);
+                if (invalidChar) {
+                    throw Error(errorMessages.ADDRESS_COUNTRY_INVALID_CHARACTERS + invalidChar);
+                }
+                return true;
+            })
+    ];
+
+export const validate = (validationErrors) => {
+    let addressCountyError;
+    let addressCountryError;
+    let addressLineOneError;
+    let addressLineTwoError;
+    let addressPostcodeError;
+    let addressTownError;
+    let firstNameError;
+    let lastNameError;
+
+    const validationErrorList = validationErrors.array({ onlyFirstError: true }).map((error) => {
+        const govUkErrorData: GovUkErrorData = createGovUkErrorData(error.msg, "#" + error.param, true, "");
+        switch (error.param) {
+        case FIRST_NAME_FIELD:
+            firstNameError = govUkErrorData;
+            break;
+        case LAST_NAME_FIELD:
+            lastNameError = govUkErrorData;
+            break;
+        case ADDRESS_LINE_ONE_FIELD:
+            addressLineOneError = govUkErrorData;
+            break;
+        case ADDRESS_LINE_TWO_FIELD:
+            addressLineTwoError = govUkErrorData;
+            break;
+        case ADDRESS_TOWN_FIELD:
+            addressTownError = govUkErrorData;
+            break;
+        case ADDRESS_COUNTY_FIELD:
+            addressCountyError = govUkErrorData;
+            break;
+        case ADDRESS_POSTCODE_FIELD:
+            addressPostcodeError = govUkErrorData;
+            break;
+        case ADDRESS_COUNTRY_FIELD:
+            addressCountryError = govUkErrorData;
+            break;
+        }
+        if (error.msg === errorMessages.ADDRESS_COUNTY_AND_POSTCODE_EMPTY) {
+            addressCountyError = createGovUkErrorData(errorMessages.ADDRESS_COUNTY_EMPTY, "#" + error.param, true, "");
+            addressPostcodeError = createGovUkErrorData(
+                errorMessages.ADDRESS_POSTCODE_EMPTY, "#" + error.param, true, "");
+        }
+        return govUkErrorData;
+    });
+    return {
+        errorList: validationErrorList,
+        addressCountyError,
+        addressCountryError,
+        addressLineOneError,
+        addressLineTwoError,
+        addressPostcodeError,
+        addressTownError,
+        firstNameError,
+        lastNameError
+    };
+};

--- a/src/views/delivery-details.html
+++ b/src/views/delivery-details.html
@@ -1,10 +1,16 @@
 {% extends "layout.html" %}
 
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% block pageTitle %}
     {% if errorList.length > 0 %}
-        Error:
-    {% endif %}
+        Error: {{ pageTitleText }}
+    {% else %}
         {{ pageTitleText }}
+    {% endif %}
 {% endblock %}
 
 {% block beforeContent %}
@@ -134,5 +140,5 @@
     {% endcall %}
     </form>
   </div>
-</div>  
-{% endblock %} 
+</div>
+{% endblock %}

--- a/src/views/delivery-details.html
+++ b/src/views/delivery-details.html
@@ -1,0 +1,138 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    {% if errorList.length > 0 %}
+        Error:
+    {% endif %}
+        {{ pageTitleText }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        {% call govukFieldset({
+          legend: {
+            text: "What are the delivery details?",
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        }) %}
+
+        {% if errorList.length > 0 %}
+          {{ govukErrorSummary({
+            titleText: ERROR_SUMMARY_TITLE,
+            errorList: errorList
+          }) }}
+        {% endif %}
+
+        {% if collectionErr.flag %}
+          {% set collectionErrorMessage = {
+            text: collectionErr.text
+          } %}
+        {% endif %}
+
+        {{ govukInput({
+          label: {
+            text: "First name"
+          },
+        classes: "govuk-!-width-two-thirds",
+        id: "firstName",
+        name: "firstName",
+        value: firstName,
+        errorMessage: firstNameError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Last name"
+          },
+        classes: "govuk-!-width-two-thirds",
+        id: "lastName",
+        name: "lastName",
+        value: lastName,
+        errorMessage: lastNameError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+          },
+          id: "addressLineOne",
+          name: "addressLineOne",
+          value: addressLineOne,
+          autocomplete: "address-line1",
+          errorMessage: addressLineOneError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+          },
+          id: "addressLineTwo",
+          name: "addressLineTwo",
+          value: addressLineTwo,
+          autocomplete: "address-line2",
+          errorMessage: addressLineTwoError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Town or city"
+          },
+        classes: "govuk-!-width-two-thirds",
+        id: "addressTown",
+        name: "addressTown",
+        value: addressTown,
+        errorMessage: addressTownError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "County"
+          },
+        classes: "govuk-!-width-two-thirds",
+        id: "addressCounty",
+        name: "addressCounty",
+        value: addressCounty,
+        errorMessage: addressCountyError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Postcode"
+          },
+        classes: "govuk-input--width-10",
+        id: "addressPostcode",
+        name: "addressPostcode",
+        value: addressPostcode,
+        errorMessage: addressPostcodeError
+        }) }}
+
+        {{ govukInput({
+          label: {
+            text: "Country"
+          },
+        classes: "govuk-!-width-two-thirds",
+        id: "addressCountry",
+        name: "addressCountry",
+        value: addressCountry,
+        errorMessage: addressCountryError
+        }) }}
+
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+
+    {% endcall %}
+    </form>
+  </div>
+</div>  
+{% endblock %} 


### PR DESCRIPTION
* Add new delivery details page.
* Add method to patch basket delivery details to API client.
* User will be returned to the basket details page either
upon successful postback or by navigating back.

Resolves:
[GCI-2167](https://companieshouse.atlassian.net/browse/GCI-2167)