### PR TITLE
display email copy section for cert orders of LP companies

### DIFF
--- a/src/service/ItemMapper.ts
+++ b/src/service/ItemMapper.ts
@@ -43,70 +43,41 @@ export abstract class ItemMapper {
         const deliveryMethod = this.mapDeliveryMethod(item?.itemOptions);
         const emailCopyRequired = this.mapEmailCopyRequired(item?.itemOptions);
 
-
-        let certificateDeliveryDetails;
-        // temp check to hide email section upcoming work will allow lp companies to request email
-        if (item.itemOptions.companyType as string === "limited-partnership" ) {
-            certificateDeliveryDetails = [
-                {
-                    key: {
-                        classes: "govuk-!-width-one-half",
-                        text: "Delivery method"
-                    },
-                    value: {
-                        classes: "govuk-!-width-one-half",
-                        html: "<p id='deliveryMethodValue'>" + deliveryMethod + "</p>"
-                    }
+        const  certificateDeliveryDetails = [
+            {
+                key: {
+                    classes: "govuk-!-width-one-half",
+                    text: "Delivery method"
                 },
-
-                {
-                    key: {
-                        classes: "govuk-!-width-one-half",
-                        text: "Delivery details"
-                    },
-                    value: {
-                        classes: "govuk-!-width-one-half",
-                        html: "<p id='deliveryAddressValue'>" + address + "</p>"
-                    }
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='deliveryMethodValue'>" + deliveryMethod + "</p>"
                 }
-            ]
-        } else {
-            certificateDeliveryDetails = [
-                {
-                    key: {
-                        classes: "govuk-!-width-one-half",
-                        text: "Delivery method"
-                    },
-                    value: {
-                        classes: "govuk-!-width-one-half",
-                        html: "<p id='deliveryMethodValue'>" + deliveryMethod + "</p>"
-                    }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-half",
+                    text: "Email copy required"
                 },
-                {
-                    key: {
-                        classes: "govuk-!-width-one-half",
-                        text: "Email copy required"
-                    },
-                    value: {
-                        classes: "govuk-!-width-one-half",
-                        html: "<p id='emailCopyRequiredValue'>" + emailCopyRequired + "</p>"
-                    }
-                },
-
-                {
-                    key: {
-                        classes: "govuk-!-width-one-half",
-                        text: "Delivery details"
-                    },
-                    value: {
-                        classes: "govuk-!-width-one-half",
-                        html: "<p id='deliveryAddressValue'>" + address + "</p>"
-                    }
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='emailCopyRequiredValue'>" + emailCopyRequired + "</p>"
                 }
-            ]
-        }
+            },
+            {
+                key: {
+                    classes: "govuk-!-width-one-half",
+                    text: "Delivery details"
+                },
+                value: {
+                    classes: "govuk-!-width-one-half",
+                    html: "<p id='deliveryAddressValue'>" + address + "</p>"
+                }
+            }
+        ]
         return certificateDeliveryDetails;
-    }
+    };
+
     abstract getOrdersDetailTable(item: { companyName: string, companyNumber: string, itemOptions: CertificateItemOptions }): any;
 
     mapDeliveryDetails = (deliveryDetails: DeliveryDetails | undefined): string => {

--- a/src/test/__mocks__/order.mocks.ts
+++ b/src/test/__mocks__/order.mocks.ts
@@ -78,6 +78,7 @@ export const mockDissolvedCertificateItem: Item = {
         certificateType: "dissolution",
         deliveryMethod: "postal",
         deliveryTimescale: "standard",
+        includeEmailCopy: false,
         directorDetails: {},
         forename: "forename",
         registeredOfficeAddressDetails: {},

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -104,6 +104,7 @@ describe("order.confirmation.controller.integration", () => {
                         certificateType: "incorporation-with-all-name-changes",
                         deliveryMethod: "postal",
                         deliveryTimescale: "standard",
+                        includeEmailCopy: false,
                         forename: "forename",
                         includeGoodStandingInformation: true,
                         registeredOfficeAddressDetails: {
@@ -151,6 +152,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#certificateTypeValue").text()).to.equal("Incorporation with all company name changes");
                     chai.expect($("#statementOfGoodStandingValue").html()).to.equal("Yes");
                     chai.expect($("#deliveryMethodValue").text()).to.equal("Standard delivery (aim to dispatch within 10 working days)");
+                    chai.expect($("#emailCopyRequiredValue").text()).to.equal("Email only available for express delivery method");
                     chai.expect($("#deliveryAddressValue").html()).to.equal(MapUtil.mapToHtml(["forename surname", "address line 1", "address line 2", "locality", "region", "postal code", "country"]));
                     chai.expect($("#paymentAmountValue").text()).to.equal("£15");
                     chai.expect($("#paymentReferenceValue").text()).to.equal(mockCertificateCheckoutResponse.paymentReference);
@@ -175,6 +177,7 @@ describe("order.confirmation.controller.integration", () => {
                     certificateType: "incorporation-with-all-name-changes",
                     deliveryMethod: "postal",
                     deliveryTimescale: "standard",
+                    includeEmailCopy: false,
                     forename: "forename",
                     includeGoodStandingInformation: true,
                     principalPlaceOfBusinessDetails: {
@@ -215,6 +218,7 @@ describe("order.confirmation.controller.integration", () => {
                 chai.expect($("#certificateTypeValue").text()).to.equal("Incorporation with all company name changes");
                 chai.expect($("#statementOfGoodStandingValue").html()).to.equal("Yes");
                 chai.expect($("#deliveryMethodValue").text()).to.equal("Standard delivery (aim to dispatch within 10 working days)");
+                chai.expect($("#emailCopyRequiredValue").text()).to.equal("Email only available for express delivery method");
                 chai.expect($("#deliveryAddressValue").html()).to.equal(MapUtil.mapToHtml(["forename surname", "address line 1", "address line 2", "locality", "region", "postal code", "country"]));
                 chai.expect($("#paymentAmountValue").text()).to.equal("£15");
                 chai.expect($("#paymentReferenceValue").text()).to.equal(mockCertificateCheckoutResponse.paymentReference);
@@ -250,6 +254,7 @@ describe("order.confirmation.controller.integration", () => {
                 chai.expect($("#companyNameValue").text()).to.equal(mockDissolvedCertificateCheckoutResponse.items[0].companyName);
                 chai.expect($("#companyNumberValue").text()).to.equal(mockDissolvedCertificateCheckoutResponse.items[0].companyNumber);
                 chai.expect($("#certificateTypeValue").text()).to.equal("Dissolution with all company name changes");
+                chai.expect($("#emailCopyRequiredValue").text()).to.equal("Email only available for express delivery method");
                 chai.expect($("#deliveryMethodValue").text()).to.equal("Standard delivery (aim to dispatch within 10 working days)");
                 chai.expect($("#deliveryAddressValue").html()).to.equal(MapUtil.mapToHtml(["forename surname", "address line 1", "address line 2", "locality", "region", "postal code", "country"]));
                 chai.expect($("#paymentAmountValue").text()).to.equal("£15");


### PR DESCRIPTION
remove logic blocking email copy section for LP companies 
update tests for email copy output - covers lp, llp and dissolved orders

Resolves: BI-11290