### PR TITLE
GCI-2149 Implement abbreviated order confirmation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.19.tgz",
-      "integrity": "sha512-uod7ET3gXDV7VoKG2n56gcnHJq79MQRKpP09q8+0z37Ta0NPJfrzEIIaKaNaXft6BHwM6wN9n6Vtko2web2dEA==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.26.tgz",
+      "integrity": "sha512-Fun6CaTlWftHs2hiCjTe1/s4BDvydvACXSsHHysn2bAdykzD30By5rupXUJkO7lw8ZWXBhPWAYthSrFYCEK+0Q==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.19",
+    "@companieshouse/api-sdk-node": "^2.0.26",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/src/controllers/ConfirmationTemplateFactory.ts
+++ b/src/controllers/ConfirmationTemplateFactory.ts
@@ -1,4 +1,6 @@
 import { ConfirmationTemplateMapper } from "./ConfirmationTemplateMapper";
+import { SingleItemTemplateMapper } from "./SingleItemTemplateMapper";
+import { OrderSummaryTemplateMapper } from "./OrderSummaryTemplateMapper";
 
 export type Enrollable = { enrolled: boolean };
 
@@ -11,7 +13,8 @@ export class DefaultConfirmationTemplateFactory implements ConfirmationTemplateF
     private disenrolledTemplateMapper: ConfirmationTemplateMapper;
     private enrolledTemplateMapper: ConfirmationTemplateMapper;
 
-    constructor (disenrolledTemplateMapper: ConfirmationTemplateMapper, enrolledTemplateMapper: ConfirmationTemplateMapper) {
+    constructor (disenrolledTemplateMapper: ConfirmationTemplateMapper = new SingleItemTemplateMapper(),
+        enrolledTemplateMapper: ConfirmationTemplateMapper = new OrderSummaryTemplateMapper()) {
         this.disenrolledTemplateMapper = disenrolledTemplateMapper;
         this.enrolledTemplateMapper = enrolledTemplateMapper;
     }

--- a/src/controllers/ConfirmationTemplateFactory.ts
+++ b/src/controllers/ConfirmationTemplateFactory.ts
@@ -1,0 +1,26 @@
+import { ConfirmationTemplateMapper } from "./ConfirmationTemplateMapper";
+
+export type Enrollable = { enrolled: boolean };
+
+export interface ConfirmationTemplateFactory {
+    getMapper(basket: Enrollable): ConfirmationTemplateMapper;
+}
+
+export class DefaultConfirmationTemplateFactory implements ConfirmationTemplateFactory {
+
+    private disenrolledTemplateMapper: ConfirmationTemplateMapper;
+    private enrolledTemplateMapper: ConfirmationTemplateMapper;
+
+    constructor (disenrolledTemplateMapper: ConfirmationTemplateMapper, enrolledTemplateMapper: ConfirmationTemplateMapper) {
+        this.disenrolledTemplateMapper = disenrolledTemplateMapper;
+        this.enrolledTemplateMapper = enrolledTemplateMapper;
+    }
+
+    getMapper(basket: Enrollable): ConfirmationTemplateMapper {
+        if (basket.enrolled) {
+            return this.enrolledTemplateMapper;
+        } else {
+            return this.disenrolledTemplateMapper;
+        }
+    }
+}

--- a/src/controllers/ConfirmationTemplateMapper.ts
+++ b/src/controllers/ConfirmationTemplateMapper.ts
@@ -1,6 +1,5 @@
-import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
-import {mapDate} from "../utils/date.util";
+import { mapDate } from "../utils/date.util";
 
 export const CERTIFICATE_PAGE_TITLE = "Certificate ordered - Order a certificate - GOV.UK";
 export const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document - GOV.UK";
@@ -18,11 +17,12 @@ export type OrderDetails = {
 };
 
 export interface ConfirmationTemplateMapper {
-    map(item: Checkout): Record<string, any>;
+    map (checkout: Checkout): Record<string, any>;
 }
 
 export abstract class AbstractTemplateMapper implements ConfirmationTemplateMapper {
-    abstract map (item: Checkout): Record<string, any>;
+    abstract map (checkout: Checkout): Record<string, any>;
+
     protected getPaymentDetails (checkout: Checkout): PaymentDetails {
         return {
             amount: "£" + checkout?.totalOrderCost,

--- a/src/controllers/ConfirmationTemplateMapper.ts
+++ b/src/controllers/ConfirmationTemplateMapper.ts
@@ -1,12 +1,21 @@
 import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
-import { mapItem } from "../service/map.item.service";
-import { mapDate } from "../utils/date.util";
-import { ORDER_COMPLETE } from "../model/template.paths";
+import {mapDate} from "../utils/date.util";
 
 export const CERTIFICATE_PAGE_TITLE = "Certificate ordered - Order a certificate - GOV.UK";
 export const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document - GOV.UK";
 export const MID_PAGE_TITLE = "Document Requested - Request a document - GOV.UK";
+
+export type PaymentDetails = {
+    amount: string;
+    paymentReference: string;
+    orderedAt: string;
+};
+
+export type OrderDetails = {
+    referenceNumber: string;
+    referenceNumberAriaLabel: string;
+};
 
 export interface ConfirmationTemplateMapper {
     map(item: Checkout): Record<string, any>;
@@ -14,62 +23,18 @@ export interface ConfirmationTemplateMapper {
 
 export abstract class AbstractTemplateMapper implements ConfirmationTemplateMapper {
     abstract map (item: Checkout): Record<string, any>;
-    protected abstract getPiwikURL(item: Item): string;
-}
-
-export class SingleItemTemplateMapper extends AbstractTemplateMapper {
-    map (checkout: Checkout): Record<string, any> {
-        const item = checkout.items[0];
-        const mappedItem = mapItem(item, checkout?.deliveryDetails);
-        const companyNumber = item.companyNumber;
-        const orderDetails = {
-            referenceNumber: checkout.reference,
-            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
-        };
-        const paymentDetails = {
+    protected getPaymentDetails (checkout: Checkout): PaymentDetails {
+        return {
             amount: "£" + checkout?.totalOrderCost,
             paymentReference: checkout.paymentReference,
             orderedAt: mapDate(checkout.paidAt)
         };
-        const itemKind = item.kind;
-        const piwikLink = this.getPiwikURL(item);
-        const totalItemsCost = `£${item?.totalItemCost}`;
-        const templateName = ORDER_COMPLETE;
-        const pageTitleText = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
-            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
+    }
 
+    protected getOrderDetails (checkout: Checkout): OrderDetails {
         return {
-            ...mappedItem,
-            companyNumber,
-            orderDetails,
-            paymentDetails,
-            itemKind,
-            piwikLink,
-            totalItemsCost,
-            templateName,
-            pageTitleText
-        }
-    }
-
-    protected getPiwikURL (item: Item): string {
-        if (item?.kind === "item#certificate") {
-            return "certificates";
-        }
-
-        if (item?.kind === "item#certified-copy") {
-            return "certified-copies";
-        }
-
-        return "";
-    }
-}
-
-export class OrderSummaryTemplateMapper extends AbstractTemplateMapper {
-    map (item: Checkout): Record<string, any> {
-        return undefined as any;
-    }
-
-    protected getPiwikURL (item: Item): string {
-        return "";
+            referenceNumber: checkout.reference,
+            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
+        };
     }
 }

--- a/src/controllers/ConfirmationTemplateMapper.ts
+++ b/src/controllers/ConfirmationTemplateMapper.ts
@@ -1,5 +1,4 @@
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
-import { mapDate } from "../utils/date.util";
 
 export const CERTIFICATE_PAGE_TITLE = "Certificate ordered - Order a certificate - GOV.UK";
 export const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document - GOV.UK";
@@ -18,23 +17,4 @@ export type OrderDetails = {
 
 export interface ConfirmationTemplateMapper {
     map (checkout: Checkout): Record<string, any>;
-}
-
-export abstract class AbstractTemplateMapper implements ConfirmationTemplateMapper {
-    abstract map (checkout: Checkout): Record<string, any>;
-
-    protected getPaymentDetails (checkout: Checkout): PaymentDetails {
-        return {
-            amount: "£" + checkout?.totalOrderCost,
-            paymentReference: checkout.paymentReference,
-            orderedAt: mapDate(checkout.paidAt)
-        };
-    }
-
-    protected getOrderDetails (checkout: Checkout): OrderDetails {
-        return {
-            referenceNumber: checkout.reference,
-            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
-        };
-    }
 }

--- a/src/controllers/ConfirmationTemplateMapper.ts
+++ b/src/controllers/ConfirmationTemplateMapper.ts
@@ -1,0 +1,75 @@
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import { mapItem } from "../service/map.item.service";
+import { mapDate } from "../utils/date.util";
+import { ORDER_COMPLETE } from "../model/template.paths";
+
+export const CERTIFICATE_PAGE_TITLE = "Certificate ordered - Order a certificate - GOV.UK";
+export const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document - GOV.UK";
+export const MID_PAGE_TITLE = "Document Requested - Request a document - GOV.UK";
+
+export interface ConfirmationTemplateMapper {
+    map(item: Checkout): Record<string, any>;
+}
+
+export abstract class AbstractTemplateMapper implements ConfirmationTemplateMapper {
+    abstract map (item: Checkout): Record<string, any>;
+    protected abstract getPiwikURL(item: Item): string;
+}
+
+export class SingleItemTemplateMapper extends AbstractTemplateMapper {
+    map (checkout: Checkout): Record<string, any> {
+        const item = checkout.items[0];
+        const mappedItem = mapItem(item, checkout?.deliveryDetails);
+        const companyNumber = item.companyNumber;
+        const orderDetails = {
+            referenceNumber: checkout.reference,
+            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
+        };
+        const paymentDetails = {
+            amount: "£" + checkout?.totalOrderCost,
+            paymentReference: checkout.paymentReference,
+            orderedAt: mapDate(checkout.paidAt)
+        };
+        const itemKind = item.kind;
+        const piwikLink = this.getPiwikURL(item);
+        const totalItemsCost = `£${item?.totalItemCost}`;
+        const templateName = ORDER_COMPLETE;
+        const pageTitleText = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
+            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
+
+        return {
+            ...mappedItem,
+            companyNumber,
+            orderDetails,
+            paymentDetails,
+            itemKind,
+            piwikLink,
+            totalItemsCost,
+            templateName,
+            pageTitleText
+        }
+    }
+
+    protected getPiwikURL (item: Item): string {
+        if (item?.kind === "item#certificate") {
+            return "certificates";
+        }
+
+        if (item?.kind === "item#certified-copy") {
+            return "certified-copies";
+        }
+
+        return "";
+    }
+}
+
+export class OrderSummaryTemplateMapper extends AbstractTemplateMapper {
+    map (item: Checkout): Record<string, any> {
+        return undefined as any;
+    }
+
+    protected getPiwikURL (item: Item): string {
+        return "";
+    }
+}

--- a/src/controllers/OrderSummaryTemplateMapper.ts
+++ b/src/controllers/OrderSummaryTemplateMapper.ts
@@ -1,18 +1,57 @@
-import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout";
-import {AbstractTemplateMapper} from "./ConfirmationTemplateMapper";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import { AbstractTemplateMapper } from "./ConfirmationTemplateMapper";
+import { ItemOptions as CertificateItemOptions} from "@companieshouse/api-sdk-node/dist/services/order/certificates";
+import { ItemOptions as CertifiedCopyItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certified-copies";
+import { ORDER_COMPLETE_ABBREVIATED } from "../model/template.paths";
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+
+export const PAGE_TITLE = "Order received - GOV.UK";
+
+type OrderStatus = {
+    hasMissingImageDeliveryItems: boolean,
+    hasExpressDeliveryItems: boolean,
+    hasStandardDeliveryItems: boolean
+};
 
 export class OrderSummaryTemplateMapper extends AbstractTemplateMapper {
     map (checkout: Checkout): Record<string, any> {
         const orderDetails = this.getOrderDetails(checkout);
         const paymentDetails = this.getPaymentDetails(checkout);
+        const orderStatus = this.buildOrderStatus(checkout.items);
         return {
-            pageTitleText: "Order received - GOV.UK",
+            pageTitleText: PAGE_TITLE,
             orderDetails,
             paymentDetails,
-            hasMissingImageDeliveryItems: true,
-            hasExpressDeliveryItems: false,
-            hasStandardDeliveryItems: false,
-            templateName: "order-complete-abbreviated"
+            ...orderStatus,
+            templateName: ORDER_COMPLETE_ABBREVIATED
+        };
+    }
+
+    private buildOrderStatus(items: Item[]): OrderStatus {
+        let hasMissingImageDeliveryItems = false;
+        let hasExpressDeliveryItems = false;
+        let hasStandardDeliveryItems = false;
+        for (const item of items) {
+            if (item.kind === "item#missing-image-delivery") {
+                hasMissingImageDeliveryItems = true;
+            } else if (item.kind === "item#certificate") {
+                if ((item.itemOptions as CertificateItemOptions).deliveryTimescale === "same-day") {
+                    hasExpressDeliveryItems = true;
+                } else {
+                    hasStandardDeliveryItems = true;
+                }
+            } else if (item.kind === "item#certified-copy") {
+                if ((item.itemOptions as CertifiedCopyItemOptions).deliveryTimescale === "same-day") {
+                    hasExpressDeliveryItems = true;
+                } else {
+                    hasStandardDeliveryItems = true;
+                }
+            }
+        }
+        return {
+            hasMissingImageDeliveryItems,
+            hasExpressDeliveryItems,
+            hasStandardDeliveryItems
         };
     }
 }

--- a/src/controllers/OrderSummaryTemplateMapper.ts
+++ b/src/controllers/OrderSummaryTemplateMapper.ts
@@ -1,0 +1,18 @@
+import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import {AbstractTemplateMapper} from "./ConfirmationTemplateMapper";
+
+export class OrderSummaryTemplateMapper extends AbstractTemplateMapper {
+    map (checkout: Checkout): Record<string, any> {
+        const orderDetails = this.getOrderDetails(checkout);
+        const paymentDetails = this.getPaymentDetails(checkout);
+        return {
+            pageTitleText: "Order received - GOV.UK",
+            orderDetails,
+            paymentDetails,
+            hasMissingImageDeliveryItems: true,
+            hasExpressDeliveryItems: false,
+            hasStandardDeliveryItems: false,
+            templateName: "order-complete-abbreviated"
+        };
+    }
+}

--- a/src/controllers/SingleItemTemplateMapper.ts
+++ b/src/controllers/SingleItemTemplateMapper.ts
@@ -1,0 +1,51 @@
+import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import {mapItem} from "../service/map.item.service";
+import {mapDate} from "../utils/date.util";
+import {ORDER_COMPLETE} from "../model/template.paths";
+import {Item} from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import {
+    AbstractTemplateMapper,
+    CERTIFICATE_PAGE_TITLE,
+    CERTIFIED_COPY_PAGE_TITLE,
+    MID_PAGE_TITLE
+} from "./ConfirmationTemplateMapper";
+
+export class SingleItemTemplateMapper extends AbstractTemplateMapper {
+    map(checkout: Checkout): Record<string, any> {
+        const item = checkout.items[0];
+        const mappedItem = mapItem(item, checkout?.deliveryDetails);
+        const companyNumber = item.companyNumber;
+        const orderDetails = this.getOrderDetails(checkout);
+        const paymentDetails = this.getPaymentDetails(checkout);
+        const itemKind = item.kind;
+        const piwikLink = this.getPiwikURL(item);
+        const totalItemsCost = `£${item?.totalItemCost}`;
+        const templateName = ORDER_COMPLETE;
+        const pageTitleText = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
+            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
+
+        return {
+            ...mappedItem,
+            companyNumber,
+            orderDetails,
+            paymentDetails,
+            itemKind,
+            piwikLink,
+            totalItemsCost,
+            templateName,
+            pageTitleText
+        };
+    }
+
+    private getPiwikURL(item: Item): string {
+        if (item?.kind === "item#certificate") {
+            return "certificates";
+        }
+
+        if (item?.kind === "item#certified-copy") {
+            return "certified-copies";
+        }
+
+        return "";
+    }
+}

--- a/src/controllers/SingleItemTemplateMapper.ts
+++ b/src/controllers/SingleItemTemplateMapper.ts
@@ -1,6 +1,5 @@
 import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import {mapItem} from "../service/map.item.service";
-import {mapDate} from "../utils/date.util";
 import {ORDER_COMPLETE} from "../model/template.paths";
 import {Item} from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 import {

--- a/src/controllers/SingleItemTemplateMapper.ts
+++ b/src/controllers/SingleItemTemplateMapper.ts
@@ -1,50 +1,51 @@
-import {Checkout} from "@companieshouse/api-sdk-node/dist/services/order/checkout";
-import {mapItem} from "../service/map.item.service";
-import {ORDER_COMPLETE} from "../model/template.paths";
-import {Item} from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import { mapItem } from "../service/map.item.service";
+import { ORDER_COMPLETE } from "../model/template.paths";
+import { Item } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 import {
-    AbstractTemplateMapper,
     CERTIFICATE_PAGE_TITLE,
     CERTIFIED_COPY_PAGE_TITLE,
+    ConfirmationTemplateMapper,
     MID_PAGE_TITLE
 } from "./ConfirmationTemplateMapper";
+import { MapUtil } from "../service/MapUtil";
 
-export class SingleItemTemplateMapper extends AbstractTemplateMapper {
-    map(checkout: Checkout): Record<string, any> {
+export class SingleItemTemplateMapper implements ConfirmationTemplateMapper {
+    map (checkout: Checkout): Record<string, any> {
         const item = checkout.items[0];
         const mappedItem = mapItem(item, checkout?.deliveryDetails);
-        const companyNumber = item.companyNumber;
-        const orderDetails = this.getOrderDetails(checkout);
-        const paymentDetails = this.getPaymentDetails(checkout);
-        const itemKind = item.kind;
-        const piwikLink = this.getPiwikURL(item);
-        const totalItemsCost = `£${item?.totalItemCost}`;
-        const templateName = ORDER_COMPLETE;
-        const pageTitleText = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
-            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
-
         return {
             ...mappedItem,
-            companyNumber,
-            orderDetails,
-            paymentDetails,
-            itemKind,
-            piwikLink,
-            totalItemsCost,
-            templateName,
-            pageTitleText
+            companyNumber: item.companyNumber,
+            orderDetails: MapUtil.getOrderDetails(checkout),
+            paymentDetails: MapUtil.getPaymentDetails(checkout),
+            itemKind: item.kind,
+            piwikLink: this.getPiwikURL(item),
+            totalItemsCost: `£${item?.totalItemCost}`,
+            templateName: ORDER_COMPLETE,
+            pageTitleText: this.getPageTitle(item.kind)
         };
     }
 
-    private getPiwikURL(item: Item): string {
+    private getPiwikURL (item: Item): string {
         if (item?.kind === "item#certificate") {
             return "certificates";
         }
-
         if (item?.kind === "item#certified-copy") {
             return "certified-copies";
         }
-
         return "";
+    }
+
+    private getPageTitle (kind: string): string {
+        if (kind === "item#certificate") {
+            return CERTIFICATE_PAGE_TITLE;
+        } else if (kind === "item#certified-copy") {
+            return CERTIFIED_COPY_PAGE_TITLE;
+        } else if (kind === "item#missing-image-delivery") {
+            return MID_PAGE_TITLE;
+        } else {
+            return "";
+        }
     }
 }

--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -2,20 +2,29 @@ import { NextFunction, Request, Response } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
-import { Item as CheckoutItem, Item as BasketItem } from "@companieshouse/api-sdk-node/dist/services/order/order";
+import { Item as BasketItem } from "@companieshouse/api-sdk-node/dist/services/order/order";
 import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-node/dist/services/order/certificates/types";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import { createLogger } from "ch-structured-logging";
 import { UserProfileKeys } from "@companieshouse/node-session-handler/lib/session/keys/UserProfileKeys";
 
-import { getCheckout, getBasket } from "../client/api.client";
-import { ORDER_COMPLETE } from "../model/template.paths";
+import { getCheckout, getBasket, getBasketLinks } from "../client/api.client";
 import { APPLICATION_NAME, RETRY_CHECKOUT_NUMBER, RETRY_CHECKOUT_DELAY } from "../config/config";
-import { mapItem } from "../service/map.item.service";
-import { mapDate } from "../utils/date.util";
 import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket";
+import { ConfirmationTemplateFactory, DefaultConfirmationTemplateFactory } from "./ConfirmationTemplateFactory";
+import { InternalServerError } from "http-errors";
 
 const logger = createLogger(APPLICATION_NAME);
+
+const factory: ConfirmationTemplateFactory = new DefaultConfirmationTemplateFactory();
+
+type CheckoutPollResult = {
+    success: boolean;
+    data?: {
+        paidAt?: string;
+        paymentReference?: string;
+    }
+};
 
 export const render = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -25,92 +34,46 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
         const signInInfo = req.session?.data[SessionKey.SignInInfo];
         const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
         const userId = signInInfo?.[SignInInfoKeys.UserProfile]?.[UserProfileKeys.UserId];
-        const CERTIFICATE_PAGE_TITLE = "Certificate ordered - Order a certificate - GOV.UK";
-        const CERTIFIED_COPY_PAGE_TITLE = "Certified document order confirmed - Order a certified document - GOV.UK";
-        const MID_PAGE_TITLE = "Document Requested - Request a document - GOV.UK";
 
         logger.info(`Order confirmation, order_id=${orderId}, ref=${ref}, status=${status}, user_id=${userId}`);
         if (status === "cancelled" || status === "failed") {
             const basket: Basket = await getBasket(accessToken);
-            const item = basket?.items?.[0];
-            const itemId = item?.id;
-            const redirectUrl: string = getRedirectUrl(item, itemId);
-            logger.info(`Redirecting to ${redirectUrl}`);
-            return res.redirect(redirectUrl);
-        };
+            if (basket.enrolled) {
+                return res.redirect("/basket");
+            } else {
+                const item = basket?.items?.[0];
+                const itemId = item?.id;
+                const redirectUrl: string = getRedirectUrl(item, itemId);
+                logger.info(`Redirecting to ${redirectUrl}`);
+                return res.redirect(redirectUrl);
+            }
+        }
 
         const checkout = (await getCheckout(accessToken, orderId)).resource as Checkout;
 
         logger.info(`Checkout retrieved checkout_id=${checkout.reference}, user_id=${userId}`);
 
-        const orderDetails = {
-            referenceNumber: checkout.reference,
-            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
-        };
-
-        const item: CheckoutItem = checkout.items[0];
-
-        const totalItemsCost = `£${item?.totalItemCost}`;
-
-        let paidAt: string = checkout?.paidAt;
-        let paymentReference: string = checkout?.paymentReference;
-
         // A race condition exists with the payment, therefore it is sometimes required to retry
-        if (paidAt === undefined || paymentReference === undefined) {
+        if (checkout?.paidAt === undefined || checkout?.paymentReference === undefined) {
             logger.info(`paid_at or payment_reference returned undefined paid_at=${checkout.paidAt}, payment_reference=${checkout.paymentReference} order_id=${orderId} - retrying get checkout`);
-            const returnedValues: string[] = await retryGetCheckout(accessToken, orderId);
-
-            paidAt = returnedValues[0];
-            paymentReference = returnedValues[1];
+            const result = await retryGetCheckout(accessToken, orderId);
+            if (result.success) {
+                checkout.paidAt = result.data?.paidAt;
+                checkout.paymentReference = result.data?.paymentReference;
+            } else {
+                throw new InternalServerError("Error polling checkout " + orderId + " for updated payment info");
+            }
         }
 
-        const paymentDetails = {
-            amount: "£" + checkout?.totalOrderCost,
-            paymentReference: paymentReference,
-            orderedAt: mapDate(paidAt)
-        };
-
-        const itemKind = item?.kind;
-        const piwikLink = getPiwikURL(item);
-
-        const mappedItem = mapItem(item, checkout?.deliveryDetails);
-
-        const pageTitle = item?.kind === "item#certificate" ? CERTIFICATE_PAGE_TITLE : item?.kind === "item#certified-copy"
-            ? CERTIFIED_COPY_PAGE_TITLE : item?.kind === "item#missing-image-delivery" ? MID_PAGE_TITLE : "";
-
-        res.render(ORDER_COMPLETE, {
-            ...mappedItem,
-            companyNumber: item?.companyNumber,
-            orderDetails,
-            paymentDetails,
-            itemKind,
-            piwikLink,
-            totalItemsCost,
-            templateName: ORDER_COMPLETE,
-            pageTitleText: pageTitle
-        });
+        const basket = await getBasketLinks(accessToken);
+        const mappedItem = factory.getMapper(basket.data).map(checkout);
+        res.render(mappedItem.templateName, mappedItem);
     } catch (err) {
         console.log(err);
         next(err);
     }
 };
 
-// TODO: rename method
-export const getPiwikURL = (item: CheckoutItem):string => {
-
-
-    if (item?.kind === "item#certificate") {
-        return "certificates";
-    }
-
-    if (item?.kind === "item#certified-copy") {
-        return "certified-copies";
-    }
-
-    return "";
-};
-
-// TODO: refactor using factory method pattern
 export const getRedirectUrl = (item: BasketItem | undefined, itemId: string | undefined):string => {
     if (item?.kind === "item#certificate") {
         const itemOptions = item?.itemOptions as CertificateItemOptions;
@@ -123,11 +86,19 @@ export const getRedirectUrl = (item: BasketItem | undefined, itemId: string | un
 };
 
 export const retryGetCheckout = async (accessToken, orderId: string) => {
-    return new Promise<string[]>(function(resolve) {
+    return new Promise<CheckoutPollResult>((resolve) => {
         let retries = 1;
         const checkoutInterval = setInterval(
             async () => {
-                const retryCheckout = (await getCheckout(accessToken, orderId)).resource as Checkout;
+                let retryCheckout;
+                try {
+                    retryCheckout = (await getCheckout(accessToken, orderId)).resource as Checkout;
+                } catch (error) {
+                    logger.error(`Failed to poll checkout resource for order_id=${orderId} with error: ${error.message}`);
+                    resolve({ success: false });
+                    clearInterval(checkoutInterval);
+                    return;
+                }
 
                 let paidAt = retryCheckout.paidAt;
                 let paymentReference = retryCheckout.paymentReference;
@@ -138,12 +109,13 @@ export const retryGetCheckout = async (accessToken, orderId: string) => {
                 } else {
                     logger.info(`paid_at and payment_reference returned successfully on retry attempt ${retries},
                         order_id=${orderId} paid_at=${paidAt}, payment_reference=${paymentReference}`);
-                    resolve([paidAt, paymentReference]);
+                    resolve({ success: true, data: { paidAt: paidAt, paymentReference: paymentReference } });
                     clearInterval(checkoutInterval);
                 }
                 if(retries >= parseInt(RETRY_CHECKOUT_NUMBER)) {
                     logger.error(`paid_at or payment_reference returned undefined after ${retries} retries,
                         order_id=${orderId} paid_at=${paidAt}, payment_reference=${paymentReference}`);
+                    resolve({ success: false });
                     clearInterval(checkoutInterval);
                 }
             }

--- a/src/model/template.paths.ts
+++ b/src/model/template.paths.ts
@@ -1,5 +1,6 @@
 export const BLANK: string = "blank";
 export const ORDER_COMPLETE: string = "order-complete";
+export const ORDER_COMPLETE_ABBREVIATED = "order-complete-abbreviated";
 export const ERROR: string = "error";
 export const ERROR_START_AGAIN: string = "error-start-again";
 export const ERROR_NOT_FOUND: string = "error-not-found";

--- a/src/service/MapUtil.ts
+++ b/src/service/MapUtil.ts
@@ -7,6 +7,9 @@ import { ItemOptions as CertificateItemOptions } from "@companieshouse/api-sdk-n
 import { createLogger } from "ch-structured-logging";
 import { AddressRecordsType } from "model/AddressRecordsType";
 import { APPLICATION_NAME, DISPATCH_DAYS } from "../config/config";
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import { mapDate } from "../utils/date.util";
+import { OrderDetails, PaymentDetails } from "../controllers/ConfirmationTemplateMapper";
 
 const escape = require("escape-html");
 const logger = createLogger(APPLICATION_NAME);
@@ -214,4 +217,19 @@ export abstract class MapUtil {
             }
         ];
     };
+
+    static getPaymentDetails = (checkout: Checkout): PaymentDetails => {
+        return {
+            amount: "£" + checkout?.totalOrderCost,
+            paymentReference: checkout.paymentReference || "",
+            orderedAt: checkout.paidAt ? mapDate(checkout.paidAt) : ""
+        };
+    }
+
+    static getOrderDetails = (checkout: Checkout): OrderDetails => {
+        return {
+            referenceNumber: checkout.reference,
+            referenceNumberAriaLabel: checkout.reference.replace(/-/g, " hyphen ")
+        };
+    }
 }

--- a/src/test/controllers/ConfirmationTemplateFactory.unit.test.ts
+++ b/src/test/controllers/ConfirmationTemplateFactory.unit.test.ts
@@ -1,0 +1,34 @@
+import { DefaultConfirmationTemplateFactory } from "../../controllers/ConfirmationTemplateFactory";
+import { ConfirmationTemplateMapper } from "../../controllers/ConfirmationTemplateMapper";
+import { expect } from "chai";
+
+describe("DefaultConfirmationTemplateFactory", () => {
+    describe("getMapper", () => {
+        it("Return mapper for disenrolled users if user is disenrolled", () => {
+            // given
+            const disenrolledMapper = {} as ConfirmationTemplateMapper;
+            const enrolledMapper = {} as ConfirmationTemplateMapper;
+            const factory = new DefaultConfirmationTemplateFactory(disenrolledMapper, enrolledMapper);
+
+            // when
+            const actual = factory.getMapper({ enrolled: false });
+
+            // then
+            expect(actual).equals(disenrolledMapper);
+        });
+
+        it("Return mapper for enrolled users if user is enrolled", () => {
+            // given
+            const disenrolledMapper = {} as ConfirmationTemplateMapper;
+            const enrolledMapper = {} as ConfirmationTemplateMapper;
+            const factory = new DefaultConfirmationTemplateFactory(disenrolledMapper, enrolledMapper);
+
+            // when
+            const actual = factory.getMapper({ enrolled: true });
+
+            // then
+            expect(actual).equals(enrolledMapper);
+        });
+
+    });
+});

--- a/src/test/controllers/ConfirmationTemplateMapper.unit.test.ts
+++ b/src/test/controllers/ConfirmationTemplateMapper.unit.test.ts
@@ -1,0 +1,81 @@
+import {
+    mockCertificateCheckoutResponse,
+    mockCertifiedCopyCheckoutResponse,
+    mockMissingImageDeliveryCheckoutResponse
+} from "../__mocks__/order.mocks";
+import {
+    CERTIFICATE_PAGE_TITLE,
+    CERTIFIED_COPY_PAGE_TITLE, MID_PAGE_TITLE,
+    SingleItemTemplateMapper
+} from "../../controllers/ConfirmationTemplateMapper";
+import { expect } from "chai";
+import { ORDER_COMPLETE } from "../../model/template.paths";
+
+describe("SingleItemTemplateMapper", () => {
+    describe("map", () => {
+        it("Maps a checkout object containing a certificate item to a view object", () => {
+            // given
+            const mapper = new SingleItemTemplateMapper();
+
+            // when
+            const actual: any = mapper.map(mockCertificateCheckoutResponse);
+
+            // then
+            expect(actual.serviceName).equals("Order a certificate");
+            expect(actual.companyNumber).equals("00000000");
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£15");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.itemKind).equals("item#certificate");
+            expect(actual.piwikLink).equals("certificates");
+            expect(actual.totalItemsCost).equals("£15");
+            expect(actual.templateName).equals(ORDER_COMPLETE);
+            expect(actual.pageTitleText).equals(CERTIFICATE_PAGE_TITLE);
+        });
+        it("Maps a checkout object containing a certified copy item to a view object", () => {
+            // given
+            const mapper = new SingleItemTemplateMapper();
+
+            // when
+            const actual: any = mapper.map(mockCertifiedCopyCheckoutResponse);
+
+            // then
+            expect(actual.serviceName).equals("Order a certified document");
+            expect(actual.companyNumber).equals("00000000");
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£30");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.itemKind).equals("item#certified-copy");
+            expect(actual.piwikLink).equals("certified-copies");
+            expect(actual.totalItemsCost).equals("£30");
+            expect(actual.templateName).equals(ORDER_COMPLETE);
+            expect(actual.pageTitleText).equals(CERTIFIED_COPY_PAGE_TITLE);
+        });
+        it("Maps a checkout object containing a missing image delivery item to a view object", () => {
+            // given
+            const mapper = new SingleItemTemplateMapper();
+
+            // when
+            const actual: any = mapper.map(mockMissingImageDeliveryCheckoutResponse);
+
+            // then
+            expect(actual.serviceName).equals("Request a document");
+            expect(actual.companyNumber).equals("00000000");
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£3");
+            expect(actual.paymentDetails.paymentReference).equals("q4nn5UxZiZxVG2e");
+            expect(actual.paymentDetails.orderedAt).equals("07 October 2020 - 11:09:46");
+            expect(actual.itemKind).equals("item#missing-image-delivery");
+            expect(actual.piwikLink).is.empty;
+            expect(actual.totalItemsCost).equals("£3");
+            expect(actual.templateName).equals(ORDER_COMPLETE);
+            expect(actual.pageTitleText).equals(MID_PAGE_TITLE);
+        });
+
+    });
+});

--- a/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
+++ b/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
@@ -1,5 +1,9 @@
 import {OrderSummaryTemplateMapper} from "../../controllers/OrderSummaryTemplateMapper";
-import {mockCertificateItem, mockMissingImageDeliveryCheckoutResponse} from "../__mocks__/order.mocks";
+import {
+    mockCertificateCheckoutResponse,
+    mockCertifiedCopyCheckoutResponse, mockCertifiedCopyItem,
+    mockMissingImageDeliveryCheckoutResponse, mockMissingImageDeliveryItem
+} from "../__mocks__/order.mocks";
 import {expect} from "chai";
 
 describe("OrderSummaryTemplateMapper", () => {
@@ -23,22 +27,119 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
-        it("It evaluates hasExpressDeliveryItems to true if order has express delivery items", () => {
+        it("It evaluates hasExpressDeliveryItems to true if order has a certificate with express delivery", () => {
             // given
             const mapper = new OrderSummaryTemplateMapper();
 
             // when
-            const actual = mapper.map({...mockCertificateItem, items: [{...mockCertificateItem.items[0], itemOptions: {...mockCertificateItem.items[0].itemOptions, deliveryTimescale: "same-day"}}]});
+            const actual = mapper.map({
+                ...mockCertificateCheckoutResponse,
+                items: [{
+                    ...mockCertificateCheckoutResponse.items[0],
+                    itemOptions: {
+                        ...mockCertificateCheckoutResponse.items[0].itemOptions,
+                        deliveryTimescale: "same-day"
+                    }
+                }]});
 
             // then
             expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
             expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
-            expect(actual.paymentDetails.amount).equals("£3");
-            expect(actual.paymentDetails.paymentReference).equals("q4nn5UxZiZxVG2e");
-            expect(actual.paymentDetails.orderedAt).equals("07 October 2020 - 11:09:46");
-            expect(actual.hasMissingImageDeliveryItems).is.true;
-            expect(actual.hasExpressDeliveryItems).is.false;
+            expect(actual.paymentDetails.amount).equals("£15");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.hasMissingImageDeliveryItems).is.false;
+            expect(actual.hasExpressDeliveryItems).is.true;
             expect(actual.hasStandardDeliveryItems).is.false;
             expect(actual.templateName).equals("order-complete-abbreviated");
+        });
+
+        it("It evaluates hasExpressDeliveryItems to true if order has a certified copy with express delivery", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map({
+                ...mockCertifiedCopyCheckoutResponse,
+                items: [{
+                    ...mockCertifiedCopyCheckoutResponse.items[0],
+                    itemOptions: {
+                        ...mockCertifiedCopyCheckoutResponse.items[0].itemOptions,
+                        deliveryTimescale: "same-day"
+                    }
+                }]});
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£30");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.hasMissingImageDeliveryItems).is.false;
+            expect(actual.hasExpressDeliveryItems).is.true;
+            expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+        });
+
+        it("It evaluates hasStandardDeliveryItems to true if order has a certificate with standard delivery", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map(mockCertificateCheckoutResponse);
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£15");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.hasMissingImageDeliveryItems).is.false;
+            expect(actual.hasExpressDeliveryItems).is.false;
+            expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+        });
+
+        it("It evaluates hasStandardDeliveryItems to true if order has a certified copy with standard delivery", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map(mockCertifiedCopyCheckoutResponse);
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£30");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.hasMissingImageDeliveryItems).is.false;
+            expect(actual.hasExpressDeliveryItems).is.false;
+            expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+        });
+
+        it("It evaluates hasMissingImageDeliveryItems, hasExpressDeliveryItems and hasStandardDeliveryItems to true if order has missing image deliveries, items with standard, express delivery", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map({...mockCertificateCheckoutResponse, items: [
+                {...mockCertificateCheckoutResponse.items[0]},
+                {...mockMissingImageDeliveryItem},
+                {...mockCertifiedCopyItem, itemOptions: { ...mockCertifiedCopyItem.itemOptions, deliveryTimescale: "same-day"}}
+            ]});
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£15");
+            expect(actual.paymentDetails.paymentReference).equals("1234567");
+            expect(actual.paymentDetails.orderedAt).equals("16 December 2019 - 09:16:17");
+            expect(actual.hasMissingImageDeliveryItems).is.true;
+            expect(actual.hasExpressDeliveryItems).is.true;
+            expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+        });
     });
 });

--- a/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
+++ b/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
@@ -24,6 +24,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.true;
             expect(actual.hasExpressDeliveryItems).is.false;
             expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.deliveryDetailsTable).to.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
@@ -51,6 +52,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.false;
             expect(actual.hasExpressDeliveryItems).is.true;
             expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.deliveryDetailsTable).to.not.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
@@ -78,6 +80,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.false;
             expect(actual.hasExpressDeliveryItems).is.true;
             expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.deliveryDetailsTable).to.not.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
@@ -97,6 +100,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.false;
             expect(actual.hasExpressDeliveryItems).is.false;
             expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.deliveryDetailsTable).to.not.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
@@ -116,6 +120,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.false;
             expect(actual.hasExpressDeliveryItems).is.false;
             expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.deliveryDetailsTable).to.not.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
 
@@ -139,6 +144,7 @@ describe("OrderSummaryTemplateMapper", () => {
             expect(actual.hasMissingImageDeliveryItems).is.true;
             expect(actual.hasExpressDeliveryItems).is.true;
             expect(actual.hasStandardDeliveryItems).is.true;
+            expect(actual.deliveryDetailsTable).to.not.be.undefined;
             expect(actual.templateName).equals("order-complete-abbreviated");
         });
     });

--- a/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
+++ b/src/test/controllers/OrderSummaryTemplateMapper.unit.test.ts
@@ -1,0 +1,44 @@
+import {OrderSummaryTemplateMapper} from "../../controllers/OrderSummaryTemplateMapper";
+import {mockCertificateItem, mockMissingImageDeliveryCheckoutResponse} from "../__mocks__/order.mocks";
+import {expect} from "chai";
+
+describe("OrderSummaryTemplateMapper", () => {
+    describe("map", () => {
+        it("It evaluates hasMissingImageDeliveryItems to true if order has missing image delivery items", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map(mockMissingImageDeliveryCheckoutResponse);
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£3");
+            expect(actual.paymentDetails.paymentReference).equals("q4nn5UxZiZxVG2e");
+            expect(actual.paymentDetails.orderedAt).equals("07 October 2020 - 11:09:46");
+            expect(actual.hasMissingImageDeliveryItems).is.true;
+            expect(actual.hasExpressDeliveryItems).is.false;
+            expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+        });
+
+        it("It evaluates hasExpressDeliveryItems to true if order has express delivery items", () => {
+            // given
+            const mapper = new OrderSummaryTemplateMapper();
+
+            // when
+            const actual = mapper.map({...mockCertificateItem, items: [{...mockCertificateItem.items[0], itemOptions: {...mockCertificateItem.items[0].itemOptions, deliveryTimescale: "same-day"}}]});
+
+            // then
+            expect(actual.orderDetails.referenceNumber).equals("ORD-123456-123456");
+            expect(actual.orderDetails.referenceNumberAriaLabel).equals("ORD hyphen 123456 hyphen 123456");
+            expect(actual.paymentDetails.amount).equals("£3");
+            expect(actual.paymentDetails.paymentReference).equals("q4nn5UxZiZxVG2e");
+            expect(actual.paymentDetails.orderedAt).equals("07 October 2020 - 11:09:46");
+            expect(actual.hasMissingImageDeliveryItems).is.true;
+            expect(actual.hasExpressDeliveryItems).is.false;
+            expect(actual.hasStandardDeliveryItems).is.false;
+            expect(actual.templateName).equals("order-complete-abbreviated");
+    });
+});

--- a/src/test/controllers/SingleItemTemplateMapper.unit.test.ts
+++ b/src/test/controllers/SingleItemTemplateMapper.unit.test.ts
@@ -6,10 +6,10 @@ import {
 import {
     CERTIFICATE_PAGE_TITLE,
     CERTIFIED_COPY_PAGE_TITLE, MID_PAGE_TITLE,
-    SingleItemTemplateMapper
 } from "../../controllers/ConfirmationTemplateMapper";
 import { expect } from "chai";
 import { ORDER_COMPLETE } from "../../model/template.paths";
+import {SingleItemTemplateMapper} from "../../controllers/SingleItemTemplateMapper";
 
 describe("SingleItemTemplateMapper", () => {
     describe("map", () => {

--- a/src/test/controllers/order.confirmation.controller.unit.test.ts
+++ b/src/test/controllers/order.confirmation.controller.unit.test.ts
@@ -3,34 +3,12 @@ import * as apiClient from "../../client/api.client";
 import chai, { expect } from "chai";
 import sinon from "sinon";
 
-import { getItemTypeUrlParam, getRedirectUrl, retryGetCheckout } from "../../controllers/order.confirmation.controller";
+import { getRedirectUrl, retryGetCheckout } from "../../controllers/order.confirmation.controller";
 import { mockCertificateItem, mockCertifiedCopyItem, mockMissingImageDeliveryItem, mockDissolvedCertificateItem, mockCertificateCheckoutResponse, ACCESS_TOKEN, ORDER_ID } from "../__mocks__/order.mocks";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 
 describe("order.confirmation.controller.unit", () => {
-    describe("getItemTypeUrlParam", () => {
-        it("get itemType for certificate correctly", () => {
-            const result = getItemTypeUrlParam(mockCertificateItem);
-            chai.expect(result).to.equal("&itemType=certificate");
-        });
-
-        it("get itemType for dissolved certificate correctly", () => {
-            const result = getItemTypeUrlParam(mockDissolvedCertificateItem);
-            chai.expect(result).to.equal("&itemType=dissolved-certificate");
-        });
-
-        it("get itemType for certified-copies correctly", () => {
-            const result = getItemTypeUrlParam(mockCertifiedCopyItem);
-            chai.expect(result).to.equal("&itemType=certified-copy");
-        });
-
-        it("get itemType for missing-image-delivery correctly", () => {
-            const result = getItemTypeUrlParam(mockMissingImageDeliveryItem);
-            chai.expect(result).to.equal("&itemType=missing-image-delivery");
-        });
-    });
-
     describe("getRedirectUrl", () => {
         it("return a redirect url correctly", () => {
             const basketItem = {

--- a/src/test/controllers/order.confirmation.controller.unit.test.ts
+++ b/src/test/controllers/order.confirmation.controller.unit.test.ts
@@ -7,6 +7,7 @@ import { getRedirectUrl, retryGetCheckout } from "../../controllers/order.confir
 import { mockCertificateItem, mockCertifiedCopyItem, mockMissingImageDeliveryItem, mockDissolvedCertificateItem, mockCertificateCheckoutResponse, ACCESS_TOKEN, ORDER_ID } from "../__mocks__/order.mocks";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
+import { InternalServerError, NotFound } from "http-errors";
 
 describe("order.confirmation.controller.unit", () => {
     describe("getRedirectUrl", () => {
@@ -42,20 +43,54 @@ describe("order.confirmation.controller.unit", () => {
         chai.expect(result).to.contain("/check-details");
     });
 
-    it("retry checkout", async () => {
-        const sandbox = sinon.createSandbox();
-        const checkoutResponse: ApiResponse<Checkout> = {
-            httpStatusCode: 200,
-            resource: mockCertificateCheckoutResponse
-        }
-        const getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        const mockCheckoutResponse = mockCertificateCheckoutResponse;
+    describe("retry checkout", async () => {
+        it("Polling successful if paidAt and paymentReference available", async () => {
+            const sandbox = sinon.createSandbox();
+            const checkoutResponse: ApiResponse<Checkout> = {
+                httpStatusCode: 200,
+                resource: mockCertificateCheckoutResponse
+            }
+            sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
 
-        const result = await retryGetCheckout(ACCESS_TOKEN, ORDER_ID);
-        expect(result[0]).to.equal(mockCheckoutResponse.paidAt)
-        expect(result[1]).to.equal(mockCheckoutResponse.paymentReference);
+            const result = await retryGetCheckout(ACCESS_TOKEN, ORDER_ID);
+            expect(result.success).to.be.true;
+            expect(result.data?.paidAt).equals(mockCertificateCheckoutResponse.paidAt);
+            expect(result.data?.paymentReference).equals(mockCertificateCheckoutResponse.paymentReference);
 
-        sandbox.reset();
-        sandbox.restore();
+            sandbox.reset();
+            sandbox.restore();
+        });
+
+        it("Polling unsuccessful if paidAt and paymentReference unavailable", async () => {
+            const sandbox = sinon.createSandbox();
+            const checkoutResponse: ApiResponse<Checkout> = {
+                httpStatusCode: 200,
+                resource: {
+                    ...mockCertificateCheckoutResponse,
+                    paidAt: undefined,
+                    paymentReference: undefined
+                }
+            }
+            sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
+
+            const result = await retryGetCheckout(ACCESS_TOKEN, ORDER_ID);
+            expect(result.success).to.be.false;
+            expect(result.data).to.be.undefined;
+
+            sandbox.reset();
+            sandbox.restore();
+        });
+
+        it("Polling unsuccessful if getCheckout endpoint returns error", async () => {
+            const sandbox = sinon.createSandbox();
+            sandbox.stub(apiClient, "getCheckout").throws(InternalServerError);
+
+            const result = await retryGetCheckout(ACCESS_TOKEN, ORDER_ID);
+            expect(result.success).to.be.false;
+            expect(result.data).to.be.undefined;
+
+            sandbox.reset();
+            sandbox.restore();
+        });
     });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,8 +20,8 @@ process.env.PIWIK_URL = "test";
 process.env.DISPATCH_DAYS = "10";
 process.env.DYNAMIC_LLP_CERTIFICATE_ORDERS_ENABLED = "true";
 process.env.DYNAMIC_LP_CERTIFICATE_ORDERS_ENABLED = "true";
-process.env.RETRY_CHECKOUT_NUMBER= "5";
-process.env.RETRY_CHECKOUT_DELAY="1500";
+process.env.RETRY_CHECKOUT_NUMBER= "1";
+process.env.RETRY_CHECKOUT_DELAY="100";
 
 
 

--- a/src/views/order-complete-abbreviated.html
+++ b/src/views/order-complete-abbreviated.html
@@ -3,6 +3,13 @@
     {{ pageTitleText }}
 {% endblock %}
 
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back to search",
+        href: CHS_URL
+    }) }}
+{% endblock %}
+
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/src/views/order-complete-abbreviated.html
+++ b/src/views/order-complete-abbreviated.html
@@ -11,62 +11,73 @@
 {% endblock %}
 
 {% block content %}
-    <h1 class="govuk-heading-m">What happens next</h1>
-    {% if hasMissingImageDeliveryItems %}
-        <p class="govuk-body">It can take us several hours to check the availability of a document.
-            We will aim to add it to a company's filing history that day if the request is received between 8:30am and 3pm, Monday to Friday (excluding bank holidays).</p>
-        <p class="govuk-body">If you make a request after 3pm, we will add the document the next working day.</p>
-    {% endif %}
-    {% if hasExpressDeliveryItems %}
-        <p class="govuk-body">Express orders received before 11am will be dispatched the same day.
-            Orders received after 11am will be dispatched the next working day.
-            We aim to dispatch standard delivery items within 10 working days.</p>
-    {% endif %}
-    {% if hasStandardDeliveryItems %}
-        <p class="govuk-body">We aim to dispatch standard delivery items within 10 working days.</p>
-    {% endif %}
-    {{ govukInsetText({
-        html: "<ul class='govuk-list'>
-            <li id='print-page-link'>
-                <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/>
-                <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-summary'>
-                    Print your order confirmation
-                </a>
-            </li>
-        </ul>"
-    }) }}
-    {% endif %}
-    <h2 class="govuk-heading-m">Your payment details</h2>
-    {{ govukSummaryList({
-        rows: [
-            {
-                key: {
-                    text: "Amount paid",
-                    classes: 'govuk-!-width-one-half'
-                },
-                value: {
-                    classes: 'govuk-!-width-one-half',
-                    html: "<p id='paymentAmountValue'>" + paymentDetails.amount + "</p>"
-                }
-            },
-            {
-                key: {
-                    text: "Payment reference"
-                },
-                value: {
-                    classes: 'govuk-!-width-one-half',
-                    html: "<p id='paymentReferenceValue'>" + paymentDetails.paymentReference + "</p>"
-                }
-            },
-            {
-                key: {
-                    text: "Date and time of payment"
-                },
-                value: {
-                    classes: 'govuk-!-width-one-half',
-                    html: "<p id='paymentTimeValue'>" + paymentDetails.orderedAt + "</p>"
-                }
-            }
-        ]
-    }) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukPanel({
+                titleText: titleText,
+                html: "Your order reference number<br><strong id='orderReference' aria-label='"+ orderDetails.referenceNumberAriaLabel + "'>" + orderDetails.referenceNumber + "</strong>"
+            }) }}
+            <h1 class="govuk-heading-m">What happens next</h1>
+            {% if hasMissingImageDeliveryItems %}
+                <p class="govuk-body">It can take us several hours to check the availability of a document.
+                    We will aim to add it to a company's filing history that day if the request is received between 8:30am and 3pm, Monday to Friday (excluding bank holidays).</p>
+                <p class="govuk-body">If you make a request after 3pm, we will add the document the next working day.</p>
+            {% endif %}
+            {% if hasExpressDeliveryItems %}
+                <p class="govuk-body">Express orders received before 11am will be dispatched the same day.
+                    Orders received after 11am will be dispatched the next working day.
+                    We aim to dispatch standard delivery items within 10 working days.</p>
+            {% endif %}
+            {% if hasStandardDeliveryItems %}
+                <p class="govuk-body">We aim to dispatch standard delivery items within 10 working days.</p>
+            {% endif %}
+            {{ govukInsetText({
+                html: "<ul class='govuk-list'>
+                    <li id='print-page-link'>
+                        <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/>
+                        <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-summary'>
+                            Print your order confirmation
+                        </a>
+                    </li>
+                </ul>"
+            }) }}
+            {% endif %}
+            <h2 class="govuk-heading-m">Your payment details</h2>
+            {{ govukSummaryList({
+                rows: [
+                    {
+                        key: {
+                            text: "Amount paid",
+                            classes: 'govuk-!-width-one-half'
+                        },
+                        value: {
+                            classes: 'govuk-!-width-one-half',
+                            html: "<p id='paymentAmountValue'>" + paymentDetails.amount + "</p>"
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Payment reference"
+                        },
+                        value: {
+                            classes: 'govuk-!-width-one-half',
+                            html: "<p id='paymentReferenceValue'>" + paymentDetails.paymentReference + "</p>"
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Date and time of payment"
+                        },
+                        value: {
+                            classes: 'govuk-!-width-one-half',
+                            html: "<p id='paymentTimeValue'>" + paymentDetails.orderedAt + "</p>"
+                        }
+                    }
+                ]
+            }) }}
+            <h2 class="govuk-heading-m">How to contact us</h2>
+            <p class="govuk-body">Email <a href="mailto:enquiries@companieshouse.gov.uk" class="govuk-link">enquiries@companieshouse.gov.uk</a> if you have questions about your order.</p>
+            <p class="govuk-body">Include your order reference number when you contact us.</p>
+        </div>
+    </div>
 {% endblock %}

--- a/src/views/order-complete-abbreviated.html
+++ b/src/views/order-complete-abbreviated.html
@@ -3,13 +3,6 @@
     {{ pageTitleText }}
 {% endblock %}
 
-{% block beforeContent %}
-    {{ govukBackLink({
-        text: "Return to company overview",
-        href: "/company/" + companyNumber
-    }) }}
-{% endblock %}
-
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -17,67 +10,104 @@
                 titleText: titleText,
                 html: "Your order reference number<br><strong id='orderReference' aria-label='"+ orderDetails.referenceNumberAriaLabel + "'>" + orderDetails.referenceNumber + "</strong>"
             }) }}
-            <h1 class="govuk-heading-m">What happens next</h1>
-            {% if hasMissingImageDeliveryItems %}
-                <p class="govuk-body">It can take us several hours to check the availability of a document.
-                    We will aim to add it to a company's filing history that day if the request is received between 8:30am and 3pm, Monday to Friday (excluding bank holidays).</p>
-                <p class="govuk-body">If you make a request after 3pm, we will add the document the next working day.</p>
-            {% endif %}
-            {% if hasExpressDeliveryItems %}
-                <p class="govuk-body">Express orders received before 11am will be dispatched the same day.
-                    Orders received after 11am will be dispatched the next working day.
-                    We aim to dispatch standard delivery items within 10 working days.</p>
-            {% endif %}
-            {% if hasStandardDeliveryItems %}
-                <p class="govuk-body">We aim to dispatch standard delivery items within 10 working days.</p>
-            {% endif %}
-            {{ govukInsetText({
-                html: "<ul class='govuk-list'>
-                    <li id='print-page-link'>
-                        <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/>
-                        <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-summary'>
-                            Print your order confirmation
-                        </a>
-                    </li>
-                </ul>"
-            }) }}
-            {% endif %}
-            <h2 class="govuk-heading-m">Your payment details</h2>
-            {{ govukSummaryList({
-                rows: [
-                    {
-                        key: {
-                            text: "Amount paid",
-                            classes: 'govuk-!-width-one-half'
-                        },
-                        value: {
-                            classes: 'govuk-!-width-one-half',
-                            html: "<p id='paymentAmountValue'>" + paymentDetails.amount + "</p>"
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Payment reference"
-                        },
-                        value: {
-                            classes: 'govuk-!-width-one-half',
-                            html: "<p id='paymentReferenceValue'>" + paymentDetails.paymentReference + "</p>"
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Date and time of payment"
-                        },
-                        value: {
-                            classes: 'govuk-!-width-one-half',
-                            html: "<p id='paymentTimeValue'>" + paymentDetails.orderedAt + "</p>"
-                        }
-                    }
-                ]
-            }) }}
-            <h2 class="govuk-heading-m">How to contact us</h2>
-            <p class="govuk-body">Email <a href="mailto:enquiries@companieshouse.gov.uk" class="govuk-link">enquiries@companieshouse.gov.uk</a> if you have questions about your order.</p>
-            <p class="govuk-body">Include your order reference number when you contact us.</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <h1 class="govuk-heading-m">What happens next</h1>
+                    {% if hasMissingImageDeliveryItems %}
+                        <div id="hasMissingImageDeliveryItems" class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <p class="govuk-body">It can take us several hours to check the availability of a document.
+                                    We will aim to add it to a company's filing history that day if the request is received between 8:30am and 3pm, Monday to Friday (excluding bank holidays).</p>
+                                <p class="govuk-body">If you make a request after 3pm, we will add the document the next working day.</p>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if hasExpressDeliveryItems %}
+                        <div id="hasExpressDeliveryItems" class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <p class="govuk-body">Express orders received before 11am will be dispatched the same day.
+                                    Orders received after 11am will be dispatched the next working day.
+                                    We aim to dispatch standard delivery items within 10 working days.</p>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if hasStandardDeliveryItems %}
+                        <div id="hasStandardDeliveryItems" class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <p class="govuk-body">We aim to dispatch standard delivery items within 10 working days.</p>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    {{ govukInsetText({
+                        html: "<ul class='govuk-list'>
+                            <li id='print-page-link'>
+                                <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/>
+                                <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-summary'>
+                                    Print your order confirmation
+                                </a>
+                            </li>
+                        </ul>"
+                    }) }}
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    {% if deliveryDetailsTable %}
+                        <h2 class="govuk-heading-m">Delivery details</h2>
+                        {{ govukSummaryList({
+                            rows: [deliveryDetailsTable]
+                        }) }}
+                    {% endif %}
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <h2 class="govuk-heading-m">Your payment details</h2>
+                    {{ govukSummaryList({
+                        rows: [
+                            {
+                                key: {
+                                    text: "Amount paid",
+                                    classes: 'govuk-!-width-one-half'
+                                },
+                                value: {
+                                    classes: 'govuk-!-width-one-half',
+                                    html: "<p id='paymentAmountValue'>" + paymentDetails.amount + "</p>"
+                                }
+                            },
+                            {
+                                key: {
+                                    text: "Payment reference"
+                                },
+                                value: {
+                                    classes: 'govuk-!-width-one-half',
+                                    html: "<p id='paymentReferenceValue'>" + paymentDetails.paymentReference + "</p>"
+                                }
+                            },
+                            {
+                                key: {
+                                    text: "Date and time of payment"
+                                },
+                                value: {
+                                    classes: 'govuk-!-width-one-half',
+                                    html: "<p id='paymentTimeValue'>" + paymentDetails.orderedAt + "</p>"
+                                }
+                            }
+                        ]
+                    }) }}
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <h2 class="govuk-heading-m">How to contact us</h2>
+                    <p class="govuk-body">Email <a href="mailto:enquiries@companieshouse.gov.uk" class="govuk-link">enquiries@companieshouse.gov.uk</a> if you have questions about your order.</p>
+                    <p class="govuk-body">Include your order reference number when you contact us.</p>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/src/views/order-complete-abbreviated.html
+++ b/src/views/order-complete-abbreviated.html
@@ -1,0 +1,72 @@
+{% extends "layout.html" %}
+{% block pageTitle %}
+    {{ pageTitleText }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Return to company overview",
+        href: "/company/" + companyNumber
+    }) }}
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-m">What happens next</h1>
+    {% if hasMissingImageDeliveryItems %}
+        <p class="govuk-body">It can take us several hours to check the availability of a document.
+            We will aim to add it to a company's filing history that day if the request is received between 8:30am and 3pm, Monday to Friday (excluding bank holidays).</p>
+        <p class="govuk-body">If you make a request after 3pm, we will add the document the next working day.</p>
+    {% endif %}
+    {% if hasExpressDeliveryItems %}
+        <p class="govuk-body">Express orders received before 11am will be dispatched the same day.
+            Orders received after 11am will be dispatched the next working day.
+            We aim to dispatch standard delivery items within 10 working days.</p>
+    {% endif %}
+    {% if hasStandardDeliveryItems %}
+        <p class="govuk-body">We aim to dispatch standard delivery items within 10 working days.</p>
+    {% endif %}
+    {{ govukInsetText({
+        html: "<ul class='govuk-list'>
+            <li id='print-page-link'>
+                <img src='/orders-assets/static/images/print-icon.png'  alt='print icon'/>
+                <a class='govuk-link' href='javascript:window.print()' data-event-id='order-confirmed-summary'>
+                    Print your order confirmation
+                </a>
+            </li>
+        </ul>"
+    }) }}
+    {% endif %}
+    <h2 class="govuk-heading-m">Your payment details</h2>
+    {{ govukSummaryList({
+        rows: [
+            {
+                key: {
+                    text: "Amount paid",
+                    classes: 'govuk-!-width-one-half'
+                },
+                value: {
+                    classes: 'govuk-!-width-one-half',
+                    html: "<p id='paymentAmountValue'>" + paymentDetails.amount + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Payment reference"
+                },
+                value: {
+                    classes: 'govuk-!-width-one-half',
+                    html: "<p id='paymentReferenceValue'>" + paymentDetails.paymentReference + "</p>"
+                }
+            },
+            {
+                key: {
+                    text: "Date and time of payment"
+                },
+                value: {
+                    classes: 'govuk-!-width-one-half',
+                    html: "<p id='paymentTimeValue'>" + paymentDetails.orderedAt + "</p>"
+                }
+            }
+        ]
+    }) }}
+{% endblock %}


### PR DESCRIPTION
* Abbreviated order summary page displayed for users enrolled for multi
  item basket.
* Implement new template for abbreviated order summary page.
* User agent redirected to /basket if payment cancelled/failed and user
  enrolled for multi-item basket.
* Fragments of text on new summary page conditionally rendered
  based on product classes ordered.
* Fix undefined behaviour if checkout API polling fails.

Resolves:
[GCI-2149](https://companieshouse.atlassian.net/browse/GCI-2149)

