### PR TITLE
GCI-2271 Implement OrderItemSummaryService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.26.tgz",
-      "integrity": "sha512-Fun6CaTlWftHs2hiCjTe1/s4BDvydvACXSsHHysn2bAdykzD30By5rupXUJkO7lw8ZWXBhPWAYthSrFYCEK+0Q==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.27.tgz",
+      "integrity": "sha512-gIuixj8UPJU6FsLMxt2a0Q6/8a9eSzWkUJsRNKDLOQn/Th3mPnTKFZ3gU8GOIitYK3nMtk8876nrUGTkwwtkSQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.27.tgz",
-      "integrity": "sha512-gIuixj8UPJU6FsLMxt2a0Q6/8a9eSzWkUJsRNKDLOQn/Th3mPnTKFZ3gU8GOIitYK3nMtk8876nrUGTkwwtkSQ==",
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.28.tgz",
+      "integrity": "sha512-n1l6p74s5OS7Nf88lIrw8MF9u7TuAvw7uWMmSDXDBTePboeegpYoCqAw9MKzlLdsJYduWGDty/3Zuigk0EW7YA==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.26",
+    "@companieshouse/api-sdk-node": "^2.0.27",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.27",
+    "@companieshouse/api-sdk-node": "^2.0.28",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -15,7 +15,7 @@ import createError from "http-errors";
 
 import { API_URL, APPLICATION_NAME, CHS_URL } from "../config/config";
 import { ORDER_COMPLETE, replaceOrderId } from "../model/page.urls";
-import { Order } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import { Item, Order } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -133,6 +133,18 @@ export const getOrder = async (orderId: string, oAuth: string): Promise<Order> =
     } else {
         logger.info(`Get order, status_code=${orderResource.value.httpStatusCode}`);
         const responseCode = orderResource.value.httpStatusCode || 500;
+        throw createError(responseCode, responseCode.toString());
+    }
+};
+
+export const getOrderItem = async (orderId: string, itemId: string, oAuth: string): Promise<Item> => {
+    const api = createApiClient(undefined, oAuth, API_URL);
+    const orderItemResource = await api.orderItem.getOrderItem(orderId, itemId);
+    if (orderItemResource.isSuccess()) {
+        return orderItemResource.value;
+    } else {
+        logger.info(`Get order, status_code=${orderItemResource.value.httpStatusCode}`);
+        const responseCode = orderItemResource.value.httpStatusCode || 500;
         throw createError(responseCode, responseCode.toString());
     }
 };

--- a/src/order_item_summary/OrderItemSummaryService.ts
+++ b/src/order_item_summary/OrderItemSummaryService.ts
@@ -1,8 +1,17 @@
 import { OrderItemRequest } from "./OrderItemRequest";
 import { OrderItemView } from "./OrderItemView";
+import { OrderItemSummaryFactory } from "./OrderItemSummaryFactory";
+import { getOrderItem } from "../client/api.client";
 
 export class OrderItemSummaryService {
+
+    constructor(private factory: OrderItemSummaryFactory = new OrderItemSummaryFactory()) {
+    }
+
     async getOrderItem (request: OrderItemRequest): Promise<OrderItemView> {
-        return undefined as any;
+        const orderItem = await getOrderItem(request.orderId, request.itemId, request.apiToken);
+        const mapper = this.factory.getMapper(orderItem);
+        mapper.map();
+        return mapper.getMappedOrder();
     }
 }

--- a/src/test/client/api.client.unit.test.ts
+++ b/src/test/client/api.client.unit.test.ts
@@ -16,13 +16,14 @@ import {
     checkoutBasket,
     createPayment,
     getBasketLinks,
-    getOrder,
+    getOrder, getOrderItem,
     patchBasket,
     removeBasketItem
 } from "../../client/api.client";
 import { NotFound } from "http-errors";
 import { OrderService } from "@companieshouse/api-sdk-node/dist/services/order";
 import { Order } from "@companieshouse/api-sdk-node/dist/services/order/order/types";
+import OrderItemService from "@companieshouse/api-sdk-node/dist/services/order/order-item/service";
 const O_AUTH_TOKEN = "oauth";
 
 const sandbox = sinon.createSandbox();
@@ -174,6 +175,22 @@ describe("api.client", () => {
                 httpStatusCode: 404
             })));
             await chai.expect(getOrder("ORD-123456-123456", "oauth")).to.be.rejectedWith(NotFound);
+        });
+    });
+
+    describe("getOrderItem", () => {
+        it("should return success 200 ok", async () => {
+            sandbox.stub(OrderItemService.prototype, "getOrderItem").returns(Promise.resolve(new Success<any, ApiErrorResponse>({
+                id: "MID-123456-123456"
+            })));
+            const item = await getOrderItem("ORD-123456-123456", "MID-123456-123456", "oauth");
+            chai.expect(item.id).to.equal("MID-123456-123456");
+        });
+        it("should throw an error if error returned by getOrder endpoint", async () => {
+            sandbox.stub(OrderItemService.prototype, "getOrderItem").returns(Promise.resolve(new Failure<any, ApiErrorResponse>({
+                httpStatusCode: 404
+            })));
+            await chai.expect(getOrderItem("ORD-123456-123456", "MID-123456-123456", "oauth")).to.be.rejectedWith(NotFound);
         });
     });
 });

--- a/src/test/order_item_summary/OrderItemSummaryService.unit.test.ts
+++ b/src/test/order_item_summary/OrderItemSummaryService.unit.test.ts
@@ -1,0 +1,69 @@
+import sinon from "sinon";
+import * as apiClient from "../../client/api.client";
+import { mockCertificateItem } from "../__mocks__/order.mocks";
+import { OrderItemSummaryService } from "../../order_item_summary/OrderItemSummaryService";
+import { expect } from "chai";
+import { InternalServerError } from "http-errors";
+
+const sandbox = sinon.createSandbox();
+
+describe("OrderItemSummaryService", () => {
+    afterEach(() => {
+        sandbox.reset();
+        sandbox.restore();
+    });
+    describe("getOrderItem", () => {
+        it("Returns a mapped order item", async () => {
+            // given
+            sandbox.stub(apiClient, "getOrderItem")
+                .returns(Promise.resolve(mockCertificateItem));
+            const mappedOrder = {};
+            const mapper = {
+                map: sandbox.spy(),
+                getMappedOrder: sandbox.stub().returns(mappedOrder)
+            }
+            const factory = {
+                getMapper: sandbox.stub().returns(mapper)
+            };
+            const service = new OrderItemSummaryService(factory);
+
+            // when
+            const actual = await service.getOrderItem({
+                apiToken: "F00DFACE",
+                orderId: "ORD-123456-123456",
+                itemId: "MID-123456-123456"
+            });
+
+            // then
+            expect(actual).to.equal(mappedOrder);
+            expect(apiClient.getOrderItem).to.be.calledOnceWith("ORD-123456-123456", "MID-123456-123456");
+            expect(mapper.getMappedOrder).to.be.calledOnce;
+            expect(factory.getMapper).to.be.calledOnceWith(mockCertificateItem);
+        });
+
+        it("Propagates exception thrown by API client", async () => {
+            // given
+            const expectedError = new InternalServerError();
+            sandbox.stub(apiClient, "getOrderItem")
+                .throws(expectedError);
+            const mappedOrder = {};
+            const mapper = {
+                map: sandbox.spy(),
+                getMappedOrder: sandbox.stub().returns(mappedOrder)
+            }
+            const factory = {
+                getMapper: sandbox.stub().returns(mapper)
+            };
+            const service = new OrderItemSummaryService(factory);
+
+            await expect(service.getOrderItem({
+                apiToken: "F00DFACE",
+                orderId: "ORD-123456-123456",
+                itemId: "MID-123456-123456"
+            })).to.be.rejectedWith(expectedError);
+            expect(apiClient.getOrderItem).to.be.calledOnceWith("ORD-123456-123456", "MID-123456-123456");
+            expect(mapper.getMappedOrder).to.not.be.called;
+            expect(factory.getMapper).to.not.be.called;
+        });
+    });
+});


### PR DESCRIPTION
* OrderItemSummaryService responsible for fetching order item resource
  from orders.api.ch.gov.uk and mapping it to an OrderItemView via the
  mapper instance returned by OrderItemSummaryFactory.
* Note: api-sdk-node needs to be rebuilt & api-sdk-node dependency needs
  to be updated prior to merging this in.

Resolves:
[GCI-2271](https://companieshouse.atlassian.net/browse/GCI-2271)