### PR TITLE
GCI-2272 Re-add itemType query param to confirmation page

### DIFF
--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -1,22 +1,22 @@
 import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
-import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket";
+import { Basket, BasketLinks } from "@companieshouse/api-sdk-node/dist/services/order/basket";
 import cheerio from "cheerio";
 
 import * as apiClient from "../../client/api.client";
 import { SIGNED_IN_COOKIE, signedInSession } from "../__mocks__/redis.mocks";
 import {
-    ORDER_ID,
     mockCertificateCheckoutResponse,
-    mockCertifiedCopyCheckoutResponse,
-    mockMissingImageDeliveryCheckoutResponse,
-    mockDissolvedCertificateCheckoutResponse,
     mockCertificateItem,
-    mockMissingImageDeliveryItem
+    mockCertifiedCopyCheckoutResponse,
+    mockDissolvedCertificateCheckoutResponse,
+    mockMissingImageDeliveryCheckoutResponse,
+    mockMissingImageDeliveryItem,
+    ORDER_ID
 } from "../__mocks__/order.mocks";
 import { MapUtil } from "../../service/MapUtil";
-import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout"
+import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import { CompanyType } from "../../model/CompanyType";
 import { DobType } from "../../model/DobType";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
@@ -24,6 +24,7 @@ import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource
 const sandbox = sinon.createSandbox();
 let testApp = null;
 let getOrderStub;
+let getBasketLinksStub;
 let getBasketStub;
 
 const ORDER_ID_ARIA_LABEL = "ORD hyphen 123456 hyphen 123456";
@@ -70,9 +71,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: true
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: true
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -93,7 +96,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#paymentTimeValue").text()).to.equal("07 October 2020 - 11:09:46");
 
                     chai.expect(getOrderStub).to.have.been.called;
-                    chai.expect(getBasketStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.contain("Order received");
                     done();
                 });
@@ -109,9 +112,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: true
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: true
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -132,7 +137,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#paymentTimeValue").text()).to.equal("16 December 2019 - 09:16:17");
 
                     chai.expect(getOrderStub).to.have.been.called;
-                    chai.expect(getBasketStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.contain("Order received");
                     done();
                 });
@@ -157,9 +162,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: true
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: true
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -180,7 +187,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#paymentTimeValue").text()).to.equal("16 December 2019 - 09:16:17");
 
                     chai.expect(getOrderStub).to.have.been.called;
-                    chai.expect(getBasketStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.contain("Order received");
                     done();
                 });
@@ -211,9 +218,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: true
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: true
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -234,7 +243,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#paymentTimeValue").text()).to.equal("16 December 2019 - 09:16:17");
 
                     chai.expect(getOrderStub).to.have.been.called;
-                    chai.expect(getBasketStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.contain("Order received");
                     done();
                 });
@@ -250,9 +259,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: false
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: false
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -278,6 +289,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#currentCompanySecretaries").html()).to.equal("Yes");
 
                     chai.expect(getOrderStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.not.contain("Your document details");
                     done();
                 });
@@ -324,9 +336,11 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-                enrolled: false
-            } as Basket));
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: false
+                }
+            } as BasketLinks));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -352,6 +366,7 @@ describe("order.confirmation.controller.integration", () => {
                     chai.expect($("#currentDesignatedMembersNames").html()).to.equal("Including designated members':<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
                     chai.expect($("#currentMembersNames").html()).to.equal("Including members':<br><br>Correspondence address<br>Appointment date<br>Country of residence<br>Date of birth (month and year)<br>");
                     chai.expect(getOrderStub).to.have.been.called;
+                    chai.expect(getBasketLinksStub).to.have.been.called;
                     chai.expect(resp.text).to.not.contain("Your document details");
                     done();
                 });
@@ -393,9 +408,11 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-            enrolled: false
-        } as Basket));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
 
         chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -422,6 +439,7 @@ describe("order.confirmation.controller.integration", () => {
                 chai.expect($("#limitedPartners").html()).to.equal("Yes");
                 chai.expect($("#generalNatureOfBusiness").html()).to.equal("Yes");
                 chai.expect(getOrderStub).to.have.been.called;
+                chai.expect(getBasketLinksStub).to.have.been.called;
                 chai.expect(resp.text).to.not.contain("Your document details");
                 done();
             });
@@ -434,9 +452,11 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-            enrolled: false
-        } as Basket));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
 
         chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -458,6 +478,7 @@ describe("order.confirmation.controller.integration", () => {
                 chai.expect($("#paymentReferenceValue").text()).to.equal(mockDissolvedCertificateCheckoutResponse.paymentReference);
                 chai.expect($("#paymentTimeValue").text()).to.equal("16 December 2019 - 09:16:17");
                 chai.expect(getOrderStub).to.have.been.called;
+                chai.expect(getBasketLinksStub).to.have.been.called;
                 chai.expect(resp.text).to.not.contain("Your document details");
                 done();
             });
@@ -470,9 +491,11 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-            enrolled: false
-        } as Basket));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
 
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certified-copy`)
@@ -501,6 +524,7 @@ describe("order.confirmation.controller.integration", () => {
         chai.expect(resp.text).to.not.contain("certificateTypeValue");
         chai.expect(resp.text).to.not.contain("includedOnCertificateValue");
         chai.expect(getOrderStub).to.have.been.called;
+        chai.expect(getBasketLinksStub).to.have.been.called;
     });
 
     it("renders get order page on successful get checkout call for a missing image delivery order", async () => {
@@ -509,9 +533,11 @@ describe("order.confirmation.controller.integration", () => {
             resource: mockMissingImageDeliveryCheckoutResponse
         }
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-            enrolled: false
-        } as Basket));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
 
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=missing-image-delivery`)
@@ -533,6 +559,7 @@ describe("order.confirmation.controller.integration", () => {
         chai.expect(resp.text).to.not.contain("certificateTypeValue");
         chai.expect(resp.text).to.not.contain("includedOnCertificateValue");
         chai.expect(getOrderStub).to.have.been.called;
+        chai.expect(getBasketLinksStub).to.have.been.called;
     });
 
     it("redirects and applies the itemType query param if user disenrolled", async () => {
@@ -542,9 +569,11 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
-            enrolled: false
-        } as Basket));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
 
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid`)
@@ -588,6 +617,11 @@ describe("order.confirmation.controller.integration", () => {
         } as unknown as Basket;
 
         it("redirects to " + itemKind.name + " check details page if status is cancelled and item type is " + itemKind.name, async () => {
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: false
+                }
+            } as BasketLinks));
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=cancelled&itemType=${itemKind.name}`)
@@ -597,6 +631,11 @@ describe("order.confirmation.controller.integration", () => {
         });
 
         it("redirects to " + itemKind.name + " check details page if status is failed and item type is " + itemKind.name, async () => {
+            getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                data: {
+                    enrolled: false
+                }
+            } as BasketLinks));
             getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(basketCancelledFailedResponse));
             const resp = await chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=${itemKind.name}`)
@@ -631,6 +670,11 @@ describe("order.confirmation.controller.integration", () => {
     } as unknown as Basket;
 
     it("redirects to dissolved certificates check details page if status is cancelled", async () => {
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
         getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=cancelled&itemType=dissolved-certificate`)
@@ -640,6 +684,11 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("redirects to dissolved certificates check details page if status is failed", async () => {
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: false
+            }
+        } as BasketLinks));
         getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve(dissolvedCertificatebasketCancelledFailedResponse));
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=failed&itemType=dissolved-certificate`)

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import sinon from "sinon";
 import ioredis from "ioredis";
-import { Basket, BasketLinks } from "@companieshouse/api-sdk-node/dist/services/order/basket";
+import { Basket } from "@companieshouse/api-sdk-node/dist/services/order/basket";
 import cheerio from "cheerio";
 
 import * as apiClient from "../../client/api.client";
@@ -70,11 +70,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: true
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: true
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -111,11 +109,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: true
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: true
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -161,11 +157,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: true
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: true
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -217,11 +211,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: true
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: true
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid`)
@@ -258,11 +250,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: false
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: false
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -334,11 +324,9 @@ describe("order.confirmation.controller.integration", () => {
             }
 
             getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-            getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-                data: {
-                    enrolled: false
-                }
-            } as BasketLinks));
+            getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+                enrolled: false
+            } as Basket));
 
             chai.request(testApp)
                 .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -405,11 +393,9 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-            data: {
-                enrolled: false
-            }
-        } as BasketLinks));
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+            enrolled: false
+        } as Basket));
 
         chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -448,11 +434,9 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-            data: {
-                enrolled: false
-            }
-        } as BasketLinks));
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+            enrolled: false
+        } as Basket));
 
         chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certificate`)
@@ -486,11 +470,9 @@ describe("order.confirmation.controller.integration", () => {
         }
 
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-            data: {
-                enrolled: false
-            }
-        } as BasketLinks));
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+            enrolled: false
+        } as Basket));
 
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=certified-copy`)
@@ -527,11 +509,9 @@ describe("order.confirmation.controller.integration", () => {
             resource: mockMissingImageDeliveryCheckoutResponse
         }
         getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
-        getBasketStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
-            data: {
-                enrolled: false
-            }
-        } as BasketLinks));
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+            enrolled: false
+        } as Basket));
 
         const resp = await chai.request(testApp)
             .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=missing-image-delivery`)
@@ -553,6 +533,24 @@ describe("order.confirmation.controller.integration", () => {
         chai.expect(resp.text).to.not.contain("certificateTypeValue");
         chai.expect(resp.text).to.not.contain("includedOnCertificateValue");
         chai.expect(getOrderStub).to.have.been.called;
+    });
+
+    it("redirects and applies the itemType query param if user disenrolled", async () => {
+        const checkoutResponse: ApiResponse<Checkout> = {
+            httpStatusCode: 200,
+            resource: mockCertificateCheckoutResponse
+        }
+
+        getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
+        getBasketStub = sandbox.stub(apiClient, "getBasket").returns(Promise.resolve({
+            enrolled: false
+        } as Basket));
+
+        const resp = await chai.request(testApp)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid`)
+            .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+            .redirects(0);
+        chai.expect(resp).to.redirectTo(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid&itemType=certificate`);
     });
 
     it("renders an error page if get order fails", (done) => {

--- a/src/test/controllers/order.confirmation.controller.unit.test.ts
+++ b/src/test/controllers/order.confirmation.controller.unit.test.ts
@@ -3,13 +3,35 @@ import * as apiClient from "../../client/api.client";
 import chai, { expect } from "chai";
 import sinon from "sinon";
 
-import { getRedirectUrl, retryGetCheckout } from "../../controllers/order.confirmation.controller";
+import { getItemTypeUrlParam, getRedirectUrl, retryGetCheckout } from "../../controllers/order.confirmation.controller";
 import { mockCertificateItem, mockCertifiedCopyItem, mockMissingImageDeliveryItem, mockDissolvedCertificateItem, mockCertificateCheckoutResponse, ACCESS_TOKEN, ORDER_ID } from "../__mocks__/order.mocks";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Checkout } from "@companieshouse/api-sdk-node/dist/services/order/checkout";
 import { InternalServerError, NotFound } from "http-errors";
 
 describe("order.confirmation.controller.unit", () => {
+    describe("getItemTypeUrlParam", () => {
+        it("get itemType for certificate correctly", () => {
+            const result = getItemTypeUrlParam(mockCertificateItem);
+            chai.expect(result).to.equal("&itemType=certificate");
+        });
+
+        it("get itemType for dissolved certificate correctly", () => {
+            const result = getItemTypeUrlParam(mockDissolvedCertificateItem);
+            chai.expect(result).to.equal("&itemType=dissolved-certificate");
+        });
+
+        it("get itemType for certified-copies correctly", () => {
+            const result = getItemTypeUrlParam(mockCertifiedCopyItem);
+            chai.expect(result).to.equal("&itemType=certified-copy");
+        });
+
+        it("get itemType for missing-image-delivery correctly", () => {
+            const result = getItemTypeUrlParam(mockMissingImageDeliveryItem);
+            chai.expect(result).to.equal("&itemType=missing-image-delivery");
+        });
+    });
+
     describe("getRedirectUrl", () => {
         it("return a redirect url correctly", () => {
             const basketItem = {


### PR DESCRIPTION
* The itemType query param is used to identify which product class a
  disenrolled user has ordered in Matomo.