### PR TITLE
add url to whitelist for orderable item

### DIFF
--- a/src/utils/request.util.ts
+++ b/src/utils/request.util.ts
@@ -4,12 +4,13 @@ import { APPLICATION_NAME } from "../config/config";
 const logger = createLogger(APPLICATION_NAME);
 
 export const ORDER_CONFIRMATION_RE = /\/orders\/ORD-\d{6}-\d{6}\/confirmation\?ref=orderable_item_ORD-\d{6}-\d{6}&state=[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}&status=[a-z]*/;
+export const ORDER_CONFIRMATION_ORDERABLE_ITEM_RE = /\/orders\/ORD-\d{6}-\d{6}\/confirmation\?ref=orderable_item_ORD-\d{6}-\d{6}/;
 export const ORDER_ITEM_SUMMARY_RE = /\/orders\/ORD-\d{6}-\d{6}\/items\/[A-Z]{3}-\d{6}-\d{6}/;
 export const ORDER_SUMMARY_RE = /\/orders\/ORD-\d{6}-\d{6}/;
 export const ORDERS_RE = /\/orders/;
 export const BASKET_RE = /\/basket/;
 export const DELIVERY_DETAILS_RE = /^\/delivery-details/;
-const REDIRECTS_WHITELIST: RegExp[] = [ORDER_CONFIRMATION_RE, ORDER_ITEM_SUMMARY_RE, ORDER_SUMMARY_RE, ORDERS_RE, BASKET_RE, DELIVERY_DETAILS_RE];
+const REDIRECTS_WHITELIST: RegExp[] = [ORDER_CONFIRMATION_RE,ORDER_CONFIRMATION_ORDERABLE_ITEM_RE, ORDER_ITEM_SUMMARY_RE, ORDER_SUMMARY_RE, ORDERS_RE, BASKET_RE, DELIVERY_DETAILS_RE];
 
 // getWhitelistedReturnToURL performs checks on the return to URL to be used in a redirect, as it is obtained from the
 // inbound request, and therefore potentially subject to forging attacks.


### PR DESCRIPTION
Add url for orderable item to whitelist, without this when a user signs out on the confirmation page and signs back in they are taken to the order summary page rather than returned back to the confirmation page.

Resolves: GCI-2281 BI-11696

