### PR TITLE
Raise InternalServerError if no error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.28.tgz",
-      "integrity": "sha512-n1l6p74s5OS7Nf88lIrw8MF9u7TuAvw7uWMmSDXDBTePboeegpYoCqAw9MKzlLdsJYduWGDty/3Zuigk0EW7YA==",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.30.tgz",
+      "integrity": "sha512-fePyjEeNVzVP4Hl5MaWifAhj08YylUGGaxz27OgNNKOn8Uuw02wTr43BwmIUiItPZqx2tMfJWVmWT1VM9Lctxg==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.28",
+    "@companieshouse/api-sdk-node": "^2.0.30",
     "@companieshouse/node-session-handler": "~4.1.6",
     "ch-structured-logging": "git+ssh://git@github.com/companieshouse/ch-structured-logging-node.git#15a811238ceb58988ab755229a5c07b9500200f2",
     "cookie-parser": "1.4.5",

--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -11,7 +11,7 @@ import { CreatePaymentRequest, Payment } from "@companieshouse/api-sdk-node/dist
 import Resource, { ApiResponse, ApiResult } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { createLogger } from "ch-structured-logging";
 import { v4 as uuidv4 } from "uuid";
-import createError from "http-errors";
+import createError, { InternalServerError } from "http-errors";
 
 import { API_URL, APPLICATION_NAME, CHS_URL } from "../config/config";
 import { ORDER_COMPLETE, replaceOrderId } from "../model/page.urls";
@@ -145,6 +145,10 @@ export const getOrderItem = async (orderId: string, itemId: string, oAuth: strin
     } else {
         logger.info(`Get order, status_code=${orderItemResource.value.httpStatusCode}`);
         const responseCode = orderItemResource.value.httpStatusCode || 500;
-        throw createError(responseCode, responseCode.toString());
+        if (orderItemResource.value.error) {
+            throw createError(responseCode, responseCode.toString());
+        } else {
+            throw new InternalServerError("Unknown error");
+        }
     }
 };


### PR DESCRIPTION
* GetOrderItem client method now throws InternalServerError if no error
  message returned by getOrderItem endpoint.

Related:
https://github.com/companieshouse/api-sdk-node/pull/451