### PR TITLE
make error page user friendly

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,11 +20,10 @@ const app = express();
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 app.use(cookieParser());
-app.use(function(req, res, next) {
-    res.header('Cache-Control', 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-     next();
+app.use(function (req, res, next) {
+    res.header("Cache-Control", "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0");
+    next();
 });
-
 
 // set some app variables from the environment
 app.set("port", process.env.PORT || "3000");

--- a/src/controllers/error.controller.ts
+++ b/src/controllers/error.controller.ts
@@ -1,18 +1,24 @@
 import { Request, Response, NextFunction } from "express";
 import { createLogger } from "ch-structured-logging";
+import { HttpError } from "http-errors";
 
-import { APPLICATION_NAME } from "../config/config";
+import { APPLICATION_NAME, CHS_URL } from "../config/config";
 import * as templatePaths from "../model/template.paths";
 
 const logger = createLogger(APPLICATION_NAME);
+const serviceName = "Find and update company information";
+const serviceUrl = CHS_URL;
 
 const notFoundHandler = (req: Request, res: Response, next: NextFunction) => {
     logger.error("Page not found: " + `${req.path}`);
-    return res.status(404).render(templatePaths.ERROR_NOT_FOUND);
+    return res.status(404).render(templatePaths.ERROR_NOT_FOUND, { serviceName, serviceUrl });
 };
 
 const errorHandler = (err: unknown, req: Request, res: Response, next: NextFunction) => {
-    res.status(500).render(templatePaths.ERROR, { errorMessage: err });
+    const errorStatusCode = err instanceof HttpError ? err?.statusCode : 500;
+    const errorName = err instanceof HttpError ? err?.name : "Error";
+    logger.error("Error: " + `${req.path}`);
+    res.status(errorStatusCode).render(templatePaths.ERROR, { errorMessage: errorName, serviceName, serviceUrl });
 };
 
 export default [notFoundHandler, errorHandler];

--- a/src/controllers/error.controller.ts
+++ b/src/controllers/error.controller.ts
@@ -15,10 +15,9 @@ const notFoundHandler = (req: Request, res: Response, next: NextFunction) => {
 };
 
 const errorHandler = (err: unknown, req: Request, res: Response, next: NextFunction) => {
-    const errorStatusCode = err instanceof HttpError ? err?.statusCode : 500;
     const errorName = err instanceof HttpError ? err?.name : "Error";
     logger.error("Error: " + `${req.path}`);
-    res.status(errorStatusCode).render(templatePaths.ERROR, { errorMessage: errorName, serviceName, serviceUrl });
+    res.status(500).render(templatePaths.ERROR, { errorMessage: errorName, serviceName, serviceUrl });
 };
 
 export default [notFoundHandler, errorHandler];

--- a/src/views/error.html
+++ b/src/views/error.html
@@ -1,13 +1,6 @@
 
 {% extends "layout.html" %}
 
-{% block header %}
-{% include "includes/cookie-banner.html" %}
- {{ govukHeader({
-    homepageUrl: "http://gov.uk/"
-  }) }}
-{% endblock %}
-
 {% block pageTitle %}
   Sorry, there is a problem with the service - Request a document - GOV.UK
 {% endblock %}


### PR DESCRIPTION
The whole error object was being displayed on the error page, the name of the error is now showing.
The error page also now displays the title in the banner and links to the chs homepage

Resolves: BI-11754