### PR TITLE
GCI-2286 Throw internal server error getOrder endpoint

### DIFF
--- a/src/client/api.client.ts
+++ b/src/client/api.client.ts
@@ -133,7 +133,11 @@ export const getOrder = async (orderId: string, oAuth: string): Promise<Order> =
     } else {
         logger.info(`Get order, status_code=${orderResource.value.httpStatusCode}`);
         const responseCode = orderResource.value.httpStatusCode || 500;
-        throw createError(responseCode, responseCode.toString());
+        if (!orderResource.value.errors && responseCode === 404) {
+            throw new InternalServerError("Unknown error");
+        } else {
+            throw createError(responseCode, responseCode.toString());
+        }
     }
 };
 
@@ -145,7 +149,7 @@ export const getOrderItem = async (orderId: string, itemId: string, oAuth: strin
     } else {
         logger.info(`Get order, status_code=${orderItemResource.value.httpStatusCode}`);
         const responseCode = orderItemResource.value.httpStatusCode || 500;
-        if (!orderItemResource.value.error && responseCode == 404) {
+        if (!orderItemResource.value.error && responseCode === 404) {
             throw new InternalServerError("Unknown error");
         } else {
             throw createError(responseCode, responseCode.toString());

--- a/src/test/client/api.client.unit.test.ts
+++ b/src/test/client/api.client.unit.test.ts
@@ -170,9 +170,18 @@ describe("api.client", () => {
         });
         it("should throw an error if error returned by getOrder endpoint", async () => {
             sandbox.stub(OrderService.prototype, "getOrder").returns(Promise.resolve(new Failure<any, ApiErrorResponse>({
-                httpStatusCode: 404
+                httpStatusCode: 404,
+                errors: [{
+                    error: "an error occurred"
+                }]
             })));
             await chai.expect(getOrder("ORD-123456-123456", "oauth")).to.be.rejectedWith(NotFound);
+        });
+        it("should throw an internal server error if no error message and HTTP 404 returned by getOrder endpoint", async () => {
+            sandbox.stub(OrderService.prototype, "getOrder").returns(Promise.resolve(new Failure<any, ApiErrorResponse>({
+                httpStatusCode: 404
+            })));
+            await chai.expect(getOrder("ORD-123456-123456", "oauth")).to.be.rejectedWith(InternalServerError);
         });
     });
 


### PR DESCRIPTION
* When orders.api is down then HTTP 404 and no errors returned by the getOrder endpoint so
* an internal server error is thrown

[GCI-2286](https://companieshouse.atlassian.net/browse/GCI-2286)