### PR TITLE
BI-13684: Append itemTypes url parameter on enrolled confirmation

### DIFF
--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -71,7 +71,9 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
             return res.redirect(getWhitelistedReturnToURL(req.originalUrl) + getItemTypeUrlParam(item));
         }
         else if (basketLinks.data.enrolled && req.query.itemTypes === undefined) {
-            return res.redirect(getWhitelistedReturnToURL(req.originalUrl) + getItemTypesUrlParam(checkout?.items));
+            const itemTypes = getItemTypesUrlParam(checkout?.items);
+            logger.info(`ItemTypes=${itemTypes}`)
+            return res.redirect(getWhitelistedReturnToURL(req.originalUrl) + itemTypes);
         }
 
         logger.info(`Checkout retrieved checkout_id=${checkout.reference}, user_id=${userId}`);

--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -70,6 +70,9 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
             const item = checkout?.items?.[0];
             return res.redirect(getWhitelistedReturnToURL(req.originalUrl) + getItemTypeUrlParam(item));
         }
+        else if (basketLinks.data.enrolled && req.query.itemTypes === undefined) {
+            return res.redirect(getWhitelistedReturnToURL(req.originalUrl) + getItemTypesUrlParam(checkout?.items));
+        }
 
         logger.info(`Checkout retrieved checkout_id=${checkout.reference}, user_id=${userId}`);
 
@@ -125,6 +128,40 @@ export const getItemTypeUrlParam = (item: CheckoutItem): string => {
     }
 
     return "";
+};
+
+export const getItemTypesUrlParam = (items: CheckoutItem[]): string => {
+    // Define the mapping of item types to their respective numbers
+    const itemTypeMap: { [key: string]: number } = {
+        'item#certificate': 1,
+        'item#certified-copy': 2,
+        'item#missing-image-delivery': 3,
+        'item#dissolution': 4
+      };
+
+    // Create a Set to store unique item type numbers
+    const uniqueItemTypes = new Set<number>();
+
+    // Loop through each item and add the corresponding number to the Set
+    items.forEach(item => {
+        if (item?.kind === "item#certificate") {
+            //Check certificate type, if it's a dissolution add it as a new type
+            const itemOptions = item.itemOptions as CertificateItemOptions;
+            if (itemOptions?.certificateType === "dissolution") {
+                uniqueItemTypes.add(itemTypeMap['item#dissolution']);
+            } else {
+                uniqueItemTypes.add(itemTypeMap['item#certificate']);
+            }
+        } else {
+            const itemTypeNumber = itemTypeMap[item.kind];
+            if (itemTypeNumber) {
+                uniqueItemTypes.add(itemTypeNumber);
+            }
+        }
+    });
+
+  // Convert the Set to an array, sort it, and join the elements with commas
+  return `&itemTypes=${Array.from(uniqueItemTypes).sort((a, b) => a - b).join(',')}`;
 };
 
 export const retryGetCheckout = async (accessToken, orderId: string) => {

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import ioredis from "ioredis";
 import { Basket, BasketLinks } from "@companieshouse/api-sdk-node/dist/services/order/basket";
 import cheerio from "cheerio";
-
+import { createLogger } from "@companieshouse/structured-logging-node";
 import * as apiClient from "../../client/api.client";
 import { SIGNED_IN_COOKIE, signedInSession } from "../__mocks__/redis.mocks";
 import {
@@ -28,6 +28,8 @@ let getBasketLinksStub;
 let getBasketStub;
 
 const ORDER_ID_ARIA_LABEL = "ORD hyphen 123456 hyphen 123456";
+const logger = createLogger("orders.web.ch.gov.uk");
+
 
 const ITEM_KINDS = [{
     kind: "item#certificate",
@@ -612,6 +614,26 @@ describe("order.confirmation.controller.integration", () => {
             .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
             .redirects(0);
         chai.expect(resp).to.redirectTo(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid&itemType=certificate`);
+    });
+
+    it("redirects and applies the itemTypes query param if user enrolled when a certificate is ordered on the confirmation page", async () => {
+        const checkoutResponse: ApiResponse<Checkout> = {
+            httpStatusCode: 200,
+            resource: mockCertificateCheckoutResponse
+        }
+
+        getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
+        getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+            data: {
+                enrolled: true
+            }
+        } as BasketLinks));
+
+        const resp = await chai.request(testApp)
+            .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid`)
+            .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+            .redirects(0);
+        chai.expect(resp).to.redirectTo(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=ff7fa274-1556-4495-b7d6-09897d877b8c&status=paid&itemTypes=1`);
     });
 
     it("renders an error page if get order fails", (done) => {

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import ioredis from "ioredis";
 import { Basket, BasketLinks } from "@companieshouse/api-sdk-node/dist/services/order/basket";
 import cheerio from "cheerio";
-import { createLogger } from "@companieshouse/structured-logging-node";
+
 import * as apiClient from "../../client/api.client";
 import { SIGNED_IN_COOKIE, signedInSession } from "../__mocks__/redis.mocks";
 import {
@@ -28,8 +28,6 @@ let getBasketLinksStub;
 let getBasketStub;
 
 const ORDER_ID_ARIA_LABEL = "ORD hyphen 123456 hyphen 123456";
-const logger = createLogger("orders.web.ch.gov.uk");
-
 
 const ITEM_KINDS = [{
     kind: "item#certificate",


### PR DESCRIPTION
This appends the itemTypes found on the confirmation page of an enrolled baskets confirmation page.
This enabled the Matomo CDN file to then use that value to send it to the Matomo analytics to track each type of the itemTypes.

They can be one of four values:

'certificate': 1,
'certified-copy': 2,
'missing-image-delivery': 3,
'dissolution': 4

