### PR TITLE
CC-1534 - Fix unknown healthcheck terraform for orders-web

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -44,6 +44,9 @@ module "ecs-service" {
   lb_listener_arn           = data.aws_lb_listener.service_lb_listener.arn
   lb_listener_rule_priority = local.lb_listener_rule_priority
   lb_listener_paths         = local.lb_listener_paths
+
+  # Healthcheck configuration
+  use_task_container_healthcheck = true
   healthcheck_path          = local.healthcheck_path
   healthcheck_matcher       = local.healthcheck_matcher
 


### PR DESCRIPTION
At the moment the healthcheck works but is not being found when checking ECS, I believe it's because in the Terraform configuration for this project the `use_task_container_healthcheck` is not set to true.

https://github.com/companieshouse/terraform-modules/blob/main/aws/ecs/ecs-service/locals.tf#L55-L67
