### PR TITLE
BI-14305- order confirmation payment reference fix

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ import {
 import * as pageUrls from "./model/page.urls";
 import errorHandlers from "./controllers/error.controller";
 import { ERROR_SUMMARY_TITLE } from "./model/error.messages";
-import { initialiseRedisClient } from "./utils/redisMethods";
+import { initialiseRedisClient } from "./utils/redis.methods";
 
 const app = express();
 
@@ -86,7 +86,7 @@ app.use((req, res, next) => {
         env.addGlobal("FEEDBACK_SOURCE", DELIVERY_DETAILS_WEB_URL);
     } else if (req.path.includes("/basket")) {
         env.addGlobal("FEEDBACK_SOURCE", BASKET_WEB_URL);
-    }else if (req.path.includes("/confirmation")) {
+    } else if (req.path.includes("/confirmation")) {
         env.addGlobal("FEEDBACK_SOURCE", ORDERS_CONFIRMATION_WEB_URL);
     }
     next();

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,8 +26,7 @@ import {
 import * as pageUrls from "./model/page.urls";
 import errorHandlers from "./controllers/error.controller";
 import { ERROR_SUMMARY_TITLE } from "./model/error.messages";
-import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
-import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
+import { initialiseRedisClient } from "./utils/redisMethods";
 
 const app = express();
 
@@ -66,6 +65,7 @@ const env = nunjucks.configure([
 
 const cookieConfig: CookieConfig = { cookieName: "__SID", cookieSecret: COOKIE_SECRET, cookieDomain: COOKIE_DOMAIN };
 const sessionStore = new SessionStore(new Redis(`redis://${CACHE_SERVER}`));
+initialiseRedisClient(sessionStore);
 
 const PROTECTED_PATHS = [pageUrls.BASKET_REMOVE, pageUrls.BASKET, pageUrls.ORDER_ITEM_SUMMARY, pageUrls.ORDER_SUMMARY, pageUrls.ORDERS, pageUrls.DELIVERY_DETAILS];
 

--- a/src/controllers/basket.controller.ts
+++ b/src/controllers/basket.controller.ts
@@ -17,7 +17,7 @@ import { BasketLink, getBasketLimit, getBasketLink } from "../utils/basket.util"
 import { BasketLimit, BasketLimitState } from "../model/BasketLimit";
 import { mapPageHeader } from "../utils/page.header.utils";
 import { PageHeader } from "../model/PageHeader";
-import { setKey } from "../utils/redisMethods";
+import { setKey } from "../utils/redis.methods";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -40,7 +40,7 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
         const continueToPaymentPath = `${BASKET_URL}${CONTINUE_TO_PAYMENT_PATH}`;
         const continueToPaymentUrl = `${CHS_URL}${continueToPaymentPath}`;
         const pageHeader = mapPageHeader(req);
-        
+
         if (req.url === addAnotherDocumentPath) {
             logger.debug(`Add another button clicked, req.url = ${req.url}`);
             if (displayBasketLimitError(req, res, basketLimit)) {
@@ -119,6 +119,7 @@ const proceedToPayment = async (req: Request, res: Response, next: NextFunction)
         const selfLink = paymentResponse?.resource?.links?.self ?? "";
         const paymentId = selfLink.split("/").pop() as string;
 
+        // set the paymentId as a key in redis with expiry of 1 hour
         await setKey(userId!, paymentId, 3600);
 
         logger.info(`Stored paymentId=${paymentId} for userId=${userId}`);

--- a/src/controllers/basket.controller.ts
+++ b/src/controllers/basket.controller.ts
@@ -17,6 +17,7 @@ import { BasketLink, getBasketLimit, getBasketLink } from "../utils/basket.util"
 import { BasketLimit, BasketLimitState } from "../model/BasketLimit";
 import { mapPageHeader } from "../utils/page.header.utils";
 import { PageHeader } from "../model/PageHeader";
+import { setKey } from "../utils/redisMethods";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -117,7 +118,10 @@ const proceedToPayment = async (req: Request, res: Response, next: NextFunction)
         // Split self link to retrieve paymentID for payment reference later
         const selfLink = paymentResponse?.resource?.links?.self ?? "";
         const paymentId = selfLink.split("/").pop() as string;
-        req.session?.setExtraData("paymentId", paymentId);
+
+        await setKey(userId!, paymentId, 3600);
+
+        logger.info(`Stored paymentId=${paymentId} for userId=${userId}`);
 
         const paymentRedirectUrl = paymentResponse.resource?.links.journey!;
         logger.info(`Payment session created, redirecting to ${paymentRedirectUrl}, reference=${paymentResponse.resource?.reference}, amount=${paymentResponse.resource?.amount}, user_id=${userId}`);

--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -16,7 +16,7 @@ import { getWhitelistedReturnToURL } from "../utils/request.util";
 import { BasketLink, getBasketLink } from "../utils/basket.util";
 import { mapPageHeader } from "../utils/page.header.utils";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
-import { getKey } from "../utils/redisMethods";
+import { getKey } from "../utils/redis.methods";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -26,7 +26,7 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
     try {
         const orderId = req.params.orderId;
         const status = req.query.status;
-        const queryRef= req.query.ref;
+        const queryRef = req.query.ref;
         const signInInfo = req.session?.data[SessionKey.SignInInfo];
         const accessToken = signInInfo?.[SignInInfoKeys.AccessToken]?.[SignInInfoKeys.AccessToken]!;
         const userId = signInInfo?.[SignInInfoKeys.UserProfile]?.[UserProfileKeys.UserId];
@@ -81,7 +81,6 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
             logger.info(`Payment reference expired or not found for userId=${userId}`);
             throw new InternalServerError("Payment reference expired or not found");
         }
-   
         logger.info(`Retrieved payment reference: ${paymentRef} for userId=${userId}`);
 
         const resource = await getPaymentDetails(paymentRef, status, queryRef, accessToken);
@@ -106,7 +105,7 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
     }
 };
 
-export const getPaymentDetails = async (paymentRef: string, status: any, queryRef: any, accessToken: string) =>{
+export const getPaymentDetails = async (paymentRef: string, status: any, queryRef: any, accessToken: string) => {
     logger.info(`Validating payment using Payments API for ref=${paymentRef}`);
     const paymentResponse = await getPaymentStatus(accessToken, paymentRef);
 

--- a/src/controllers/order.confirmation.controller.ts
+++ b/src/controllers/order.confirmation.controller.ts
@@ -16,6 +16,7 @@ import { getWhitelistedReturnToURL } from "../utils/request.util";
 import { BasketLink, getBasketLink } from "../utils/basket.util";
 import { mapPageHeader } from "../utils/page.header.utils";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment";
+import { getKey } from "../utils/redisMethods";
 
 const logger = createLogger(APPLICATION_NAME);
 
@@ -75,21 +76,26 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
 
         logger.info(`Checkout retrieved checkout_id=${checkout.reference}, user_id=${userId}`);
 
-        const paymentRef = req.session?.getExtraData("paymentId") as string;
-        
-        const resource = await getPaymentDetails(paymentRef, status , queryRef ,accessToken);
-        
+        const paymentRef = await getKey(userId!);
+        if (!paymentRef) {
+            logger.info(`Payment reference expired or not found for userId=${userId}`);
+            throw new InternalServerError("Payment reference expired or not found");
+        }
+   
+        logger.info(`Retrieved payment reference: ${paymentRef} for userId=${userId}`);
+
+        const resource = await getPaymentDetails(paymentRef, status, queryRef, accessToken);
+
         const basket: Basket = await getBasket(accessToken);
         const basketLink: BasketLink = await getBasketLink(req, basket);
 
         /*update the Payment response with the reference from the session (from CreatePayment in basket controller)
         and paymentReference from API response. 
-        */ 
+        */
         const updatedPayment: Payment = {
             ...resource,
             reference: paymentRef
-          };
-        
+        };
         const mappedItem = factory.getMapper(basketLinks.data).map(checkout, updatedPayment);
 
         res.render(mappedItem.templateName, { ...mappedItem, ...basketLink, ...pageHeader, serviceName, serviceUrl });
@@ -103,20 +109,20 @@ export const render = async (req: Request, res: Response, next: NextFunction) =>
 export const getPaymentDetails = async (paymentRef: string, status: any, queryRef: any, accessToken: string) =>{
     logger.info(`Validating payment using Payments API for ref=${paymentRef}`);
     const paymentResponse = await getPaymentStatus(accessToken, paymentRef);
-    
+
     const resource = paymentResponse.resource as Payment;  
     const reference = paymentResponse.resource?.reference;
     const paymentStatus = paymentResponse.resource?.status;
 
     // Compare 'reference' from paymentAPI response with queryParam reference
-    if (queryRef !== reference){
-        logger.error(`Payment validation failed for ${queryRef} and ${queryRef}`);
+    if (queryRef !== reference) {
+        logger.error(`Payment references validation failed references: ${queryRef} and ${reference} do not match`);
         throw new InternalServerError("Payment References do not match");
     }
 
     // Compare status from paymentAPI response with queryParam status
     if (paymentStatus !== status) {
-        logger.error(`Payment validation failed for ${queryRef} and ${queryRef}`);
+        logger.error(`Payment status validation failed statues: ${paymentStatus} and ${status} do not match}`);
         throw new InternalServerError("Payment statuses from API does not match");
     }
     return resource;
@@ -161,7 +167,7 @@ export const getItemTypesUrlParam = (items: CheckoutItem[]): string => {
         'item#certified-copy': 2,
         'item#missing-image-delivery': 3,
         'item#dissolution': 4
-      };
+    };
 
     // Create a Set to store unique item type numbers
     const uniqueItemTypes = new Set<number>();
@@ -184,6 +190,6 @@ export const getItemTypesUrlParam = (items: CheckoutItem[]): string => {
         }
     });
 
-  // Convert the Set to an array, sort it, and join the elements with commas
-  return `itemTypes=${Array.from(uniqueItemTypes).sort((a, b) => a - b).join(',')}`;
+    // Convert the Set to an array, sort it, and join the elements with commas
+    return `itemTypes=${Array.from(uniqueItemTypes).sort((a, b) => a - b).join(',')}`;
 };

--- a/src/test/__mocks__/redis.mocks.ts
+++ b/src/test/__mocks__/redis.mocks.ts
@@ -22,7 +22,8 @@ export const signedInSessionData = {
             token_type: "Bearer"
         },
         user_profile: {
-            email: "test@testemail.com"
+            email: "test@testemail.com",
+            id: "1234"
         },
         signed_in: 1
     }

--- a/src/test/controllers/basket.controller.integration.test.ts
+++ b/src/test/controllers/basket.controller.integration.test.ts
@@ -14,10 +14,10 @@ import { BASKET_ITEM_LIMIT } from "../../config/config";
 import { ADD_ANOTHER_DOCUMENT_PATH, BASKET as BASKET_URL } from "../../model/page.urls";
 import cheerio from "cheerio";
 import { verifyUserNavBarRenderedWithoutBasketLink } from "../utils/page.header.utils.test";
-import * as redisUtils from "../../utils/redisMethods"; // Adjust the path as needed
+import * as redisUtils from "../../utils/redis.methods";
 
 const sandbox = sinon.createSandbox();
-let testApp:any ;
+let testApp = null;
 let checkoutBasketStub;
 let createPaymentStub;
 

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -25,6 +25,7 @@ import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment/types";
 import { Session } from "@companieshouse/node-session-handler";
 import  *  as getWhitelistedReturnToURL from "../../utils/request.util";
+import * as redisUtils from "../../utils/redisMethods"; // Adjust the path as needed
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
@@ -32,6 +33,7 @@ let getOrderStub;
 let getBasketLinksStub;
 let getBasketStub;
 let getPaymentStub;
+let getKeyStub;
 
 const ORDER_ID_ARIA_LABEL = "ORD hyphen 123456 hyphen 123456";
 
@@ -55,7 +57,7 @@ describe("order.confirmation.controller.integration", () => {
     beforeEach(done => {
         sandbox.stub(ioredis.prototype, "connect").returns(Promise.resolve());
         sandbox.stub(ioredis.prototype, "get").returns(Promise.resolve(signedInSession));
-
+  
         testApp = getAppWithMockedCsrf(sandbox);
         done();
     });
@@ -63,13 +65,13 @@ describe("order.confirmation.controller.integration", () => {
     afterEach(() => {
         sandbox.reset();
         sandbox.restore();
+        sinon.restore();
     });
 
     describe("Certificate order confirmation page integration tests", () => {
         it("Renders order summary page if the user is enrolled and missing image delivery requested", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
   
             const certificateCheckoutResponse = {
                 ...mockMissingImageDeliveryCheckoutResponse
@@ -132,10 +134,11 @@ describe("order.confirmation.controller.integration", () => {
                     done();
                 });
         });
+
         it("Renders order summary page if the user is enrolled and standard delivery requested", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+
             const certificateCheckoutResponse = {
                 ...mockCertificateCheckoutResponse
             } as Checkout;
@@ -194,9 +197,9 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Renders order summary page if the user is enrolled and express delivery requested", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+
             const certificateCheckoutResponse = {
                 ...mockCertificateCheckoutResponse,
                 items: [
@@ -266,9 +269,9 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Renders order summary page if the user is enrolled, items with express and standard delivery requested and missing image delivery requested", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+
             const certificateCheckoutResponse = {
                 ...mockCertificateCheckoutResponse,
                 items: [
@@ -342,9 +345,8 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Correctly renders order confirmation page on for a limited company certificate order", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
       
             const certificateCheckoutResponse = {
                 ...mockCertificateCheckoutResponse
@@ -404,9 +406,9 @@ describe("order.confirmation.controller.integration", () => {
         });
 
         it("Correctly renders order confirmation page on for a LLP company certificate order", (done) => {
-            sandbox.stub(Session.prototype, "getExtraData")
-            .withArgs("paymentId")
-            .returns("q4nn5UxZiZxVG2e");
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+
             const certificateCheckoutResponse = {
                 ...mockCertificateCheckoutResponse,
                 items: [{
@@ -497,9 +499,9 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("Correctly renders order confirmation page on for a LP company certificate order", (done) => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+        
         const certificateCheckoutResponse = {
             ...mockCertificateCheckoutResponse,
             items: [{
@@ -583,9 +585,9 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a dissolved certificate order", (done) => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
+        
         const checkoutResponse: ApiResponse<Checkout> = {
             httpStatusCode: 200,
             resource: mockDissolvedCertificateCheckoutResponse
@@ -637,9 +639,8 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a certified copy order", async () => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub.resolves('q4nn5UxZiZxVG2e');
         const checkoutResponse: ApiResponse<Checkout> = {
             httpStatusCode: 200,
             resource: mockCertifiedCopyCheckoutResponse
@@ -695,9 +696,8 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a missing image delivery order", async () => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
         const checkoutResponse: ApiResponse<Checkout> = {
             httpStatusCode: 200,
@@ -745,9 +745,8 @@ describe("order.confirmation.controller.integration", () => {
         chai.expect(getBasketLinksStub).to.have.been.called;
     });
     it("should throw InternalServerError if query param reference and payment api refeernce do not match", (done) => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
        
         const wrongRef = "orderable_item_WRONG-REF";
@@ -793,10 +792,8 @@ describe("order.confirmation.controller.integration", () => {
 
 
     it("should throw InternalServerError if query param status and payment api status do not match", (done) => {
-        sandbox.stub(Session.prototype, "getExtraData")
-        .withArgs("paymentId")
-        .returns("q4nn5UxZiZxVG2e");
-        
+        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub.resolves('q4nn5UxZiZxVG2e');
         const queryParamstatus = "paid";
         const apiStatus = "failed";
 
@@ -837,6 +834,41 @@ describe("order.confirmation.controller.integration", () => {
             done();
           });
         });
+
+        it("should throw InternalServerError if payment reference not present in Redis", (done) => {
+            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+                getKeyStub.resolves('');
+    
+                const checkoutResponse: ApiResponse<Checkout> = {
+                    httpStatusCode: 200,
+                    resource: mockMissingImageDeliveryCheckoutResponse
+                }
+                getOrderStub = sandbox.stub(apiClient, "getCheckout").returns(Promise.resolve(checkoutResponse));
+                getBasketLinksStub = sandbox.stub(apiClient, "getBasketLinks").returns(Promise.resolve({
+                    data: {
+                        enrolled: false
+                    }
+                } as BasketLinks));
+                getBasketStub = sandbox.stub(apiClient, "getBasket")
+                .returns(Promise.resolve({ enrolled: true }));
+        
+                const certificatePaymentResponse: ApiResponse<Payment> = {
+                    httpStatusCode: 200,
+                    resource: mockPaymentResponse,
+                }
+                getPaymentStub = sandbox.stub(apiClient, "getPaymentStatus").returns(Promise.resolve(
+                    certificatePaymentResponse,
+                ));
+                
+                chai.request(testApp)
+                .get(`/orders/${ORDER_ID}/confirmation?ref=orderable_item_${ORDER_ID}&state=1234&status=paid&itemType=missing-image-delivery`)
+                .set("Cookie", [`__SID=${SIGNED_IN_COOKIE}`])
+                .end((err, res) => {
+                 
+                  expect(res).to.have.status(500);
+                  done();
+                });
+              });
 
 
     it("redirects and applies the itemType query param if user disenrolled", async () => {

--- a/src/test/controllers/order.confirmation.controller.integration.test.ts
+++ b/src/test/controllers/order.confirmation.controller.integration.test.ts
@@ -23,9 +23,8 @@ import { CompanyType } from "../../model/CompanyType";
 import { DobType } from "../../model/DobType";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Payment } from "@companieshouse/api-sdk-node/dist/services/payment/types";
-import { Session } from "@companieshouse/node-session-handler";
 import  *  as getWhitelistedReturnToURL from "../../utils/request.util";
-import * as redisUtils from "../../utils/redisMethods"; // Adjust the path as needed
+import * as redisUtils from "../../utils/redis.methods";
 
 const sandbox = sinon.createSandbox();
 let testApp = null;
@@ -70,7 +69,7 @@ describe("order.confirmation.controller.integration", () => {
 
     describe("Certificate order confirmation page integration tests", () => {
         it("Renders order summary page if the user is enrolled and missing image delivery requested", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
   
             const certificateCheckoutResponse = {
@@ -136,7 +135,7 @@ describe("order.confirmation.controller.integration", () => {
         });
 
         it("Renders order summary page if the user is enrolled and standard delivery requested", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
 
             const certificateCheckoutResponse = {
@@ -197,7 +196,7 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Renders order summary page if the user is enrolled and express delivery requested", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
 
             const certificateCheckoutResponse = {
@@ -269,7 +268,7 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Renders order summary page if the user is enrolled, items with express and standard delivery requested and missing image delivery requested", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
 
             const certificateCheckoutResponse = {
@@ -345,7 +344,7 @@ describe("order.confirmation.controller.integration", () => {
                 });
         });
         it("Correctly renders order confirmation page on for a limited company certificate order", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
       
             const certificateCheckoutResponse = {
@@ -406,7 +405,7 @@ describe("order.confirmation.controller.integration", () => {
         });
 
         it("Correctly renders order confirmation page on for a LLP company certificate order", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
 
             const certificateCheckoutResponse = {
@@ -499,7 +498,7 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("Correctly renders order confirmation page on for a LP company certificate order", (done) => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
         const certificateCheckoutResponse = {
@@ -585,7 +584,7 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a dissolved certificate order", (done) => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
         const checkoutResponse: ApiResponse<Checkout> = {
@@ -639,7 +638,7 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a certified copy order", async () => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
         getKeyStub.resolves('q4nn5UxZiZxVG2e');
         const checkoutResponse: ApiResponse<Checkout> = {
             httpStatusCode: 200,
@@ -696,7 +695,7 @@ describe("order.confirmation.controller.integration", () => {
     });
 
     it("renders get order page on successful get checkout call for a missing image delivery order", async () => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
         getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
         const checkoutResponse: ApiResponse<Checkout> = {
@@ -745,7 +744,7 @@ describe("order.confirmation.controller.integration", () => {
         chai.expect(getBasketLinksStub).to.have.been.called;
     });
     it("should throw InternalServerError if query param reference and payment api refeernce do not match", (done) => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
         
        
@@ -792,7 +791,7 @@ describe("order.confirmation.controller.integration", () => {
 
 
     it("should throw InternalServerError if query param status and payment api status do not match", (done) => {
-        const getKeyStub = sinon.stub(redisUtils, 'getKey');
+        getKeyStub = sinon.stub(redisUtils, 'getKey');
             getKeyStub.resolves('q4nn5UxZiZxVG2e');
         const queryParamstatus = "paid";
         const apiStatus = "failed";
@@ -836,7 +835,7 @@ describe("order.confirmation.controller.integration", () => {
         });
 
         it("should throw InternalServerError if payment reference not present in Redis", (done) => {
-            const getKeyStub = sinon.stub(redisUtils, 'getKey');
+            getKeyStub = sinon.stub(redisUtils, 'getKey');
                 getKeyStub.resolves('');
     
                 const checkoutResponse: ApiResponse<Checkout> = {

--- a/src/test/utils/redis.methods.utils.test.ts
+++ b/src/test/utils/redis.methods.utils.test.ts
@@ -1,0 +1,74 @@
+import { SessionStore } from "@companieshouse/node-session-handler/lib/session/store/SessionStore";
+import { expect } from "chai";
+import sinon from "sinon";
+
+
+import { initialiseRedisClient, setKey, getKey, deleteKey } from "../../utils/redisMethods";
+
+describe("Redis Utils", () => {
+    let sandbox: sinon.SinonSandbox;
+    let mockRedis: any;
+    let mockSessionStore: SessionStore;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        mockRedis = {
+            set: sandbox.stub().resolves(),
+            setex: sandbox.stub().resolves(),
+            get: sandbox.stub().resolves("mock-value"),
+            del: sandbox.stub().resolves()
+        };
+
+        mockSessionStore = { redis: mockRedis } as unknown as SessionStore;
+
+        initialiseRedisClient(mockSessionStore);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe("setKey", () => {
+        it("should set a key with TTL", async () => {
+            await setKey("test-key", "test-value", 60);
+            sinon.assert.calledWith(mockRedis.setex, "test-key", 60, "test-value");
+        });
+
+        it("should set a key without TTL", async () => {
+            await setKey("test-key", "test-value");
+            sinon.assert.calledWith(mockRedis.set, "test-key", "test-value");
+        });
+
+        it("should throw error if sessionStore is not initialised", async () => {
+            initialiseRedisClient(null as any); 
+
+            await expect(setKey("a", "b")).to.be.rejectedWith("SessionStore is not initialised");
+        });
+    });
+
+    describe("getKey", () => {
+        it("should return the value for a key", async () => {
+            const result = await getKey("test-key");
+            expect(result).to.equal("mock-value");
+            sinon.assert.calledWith(mockRedis.get, "test-key");
+        });
+
+        it("should throw error if sessionStore not initialised", async () => {
+            initialiseRedisClient(null as any); 
+            await expect(getKey("a")).to.be.rejectedWith("SessionStore is not initialised");
+        });
+    });
+
+    describe("deleteKey", () => {
+        it("should delete a key", async () => {
+            await deleteKey("test-key");
+            sinon.assert.calledWith(mockRedis.del, "test-key");
+        });
+
+        it("should throw error if sessionStore isnt initialised", async () => {
+            initialiseRedisClient(null as any); 
+            await expect(deleteKey("a")).to.be.rejectedWith("SessionStore is not initialised");
+        });
+    });
+});

--- a/src/test/utils/redis.methods.utils.test.ts
+++ b/src/test/utils/redis.methods.utils.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 
 
-import { initialiseRedisClient, setKey, getKey, deleteKey } from "../../utils/redisMethods";
+import { initialiseRedisClient, setKey, getKey, deleteKey } from "../../utils/redis.methods";
 
 describe("Redis Utils", () => {
     let sandbox: sinon.SinonSandbox;
@@ -41,7 +41,7 @@ describe("Redis Utils", () => {
         });
 
         it("should throw error if sessionStore is not initialised", async () => {
-            initialiseRedisClient(null as any); 
+            initialiseRedisClient(null as any);
 
             await expect(setKey("a", "b")).to.be.rejectedWith("SessionStore is not initialised");
         });
@@ -55,7 +55,7 @@ describe("Redis Utils", () => {
         });
 
         it("should throw error if sessionStore not initialised", async () => {
-            initialiseRedisClient(null as any); 
+            initialiseRedisClient(null as any);
             await expect(getKey("a")).to.be.rejectedWith("SessionStore is not initialised");
         });
     });
@@ -67,7 +67,7 @@ describe("Redis Utils", () => {
         });
 
         it("should throw error if sessionStore isnt initialised", async () => {
-            initialiseRedisClient(null as any); 
+            initialiseRedisClient(null as any);
             await expect(deleteKey("a")).to.be.rejectedWith("SessionStore is not initialised");
         });
     });

--- a/src/utils/redis.methods.ts
+++ b/src/utils/redis.methods.ts
@@ -2,10 +2,15 @@ import { SessionStore } from "@companieshouse/node-session-handler";
 
 let sessionStore: SessionStore;
 
+
+// Methods created to allow paymentReference from createPayment to be stored in Redis
+// and retrieved in the order confirmation page
 export const initialiseRedisClient = (store: SessionStore): void => {
     sessionStore = store;
 };
 
+// Set a key in Redis with an optional TTL
+// If TTL is provided, use setex otherwise use set
 export const setKey = async (key: string, value: string, ttlInSeconds?: number): Promise<void> => {
     if (!sessionStore) {
         throw new Error("SessionStore is not initialised");
@@ -17,6 +22,7 @@ export const setKey = async (key: string, value: string, ttlInSeconds?: number):
     }
 };
 
+// Get a key from Redis
 export const getKey = async (key: string): Promise<string | null> => {
     if (!sessionStore) {
         throw new Error("SessionStore is not initialised");
@@ -24,6 +30,7 @@ export const getKey = async (key: string): Promise<string | null> => {
     return sessionStore.redis.get(key);
 };
 
+// Delete a key from Redis to cleaning up expired keys or when the session is destroyed
 export const deleteKey = async (key: string): Promise<void> => {
     if (!sessionStore) {
         throw new Error("SessionStore is not initialised");

--- a/src/utils/redisMethods.ts
+++ b/src/utils/redisMethods.ts
@@ -1,0 +1,32 @@
+import { SessionStore } from "@companieshouse/node-session-handler";
+
+let sessionStore: SessionStore;
+
+export const initialiseRedisClient = (store: SessionStore): void => {
+    sessionStore = store;
+};
+
+export const setKey = async (key: string, value: string, ttlInSeconds?: number): Promise<void> => {
+    if (!sessionStore) {
+        throw new Error("SessionStore is not initialised");
+    }
+    if (ttlInSeconds) {
+        await sessionStore.redis.setex(key, ttlInSeconds, value);
+    } else {
+        await sessionStore.redis.set(key, value);
+    }
+};
+
+export const getKey = async (key: string): Promise<string | null> => {
+    if (!sessionStore) {
+        throw new Error("SessionStore is not initialised");
+    }
+    return await sessionStore.redis.get(key);
+};
+
+export const deleteKey = async (key: string): Promise<void> => {
+    if (!sessionStore) {
+        throw new Error("SessionStore is not initialised");
+    }
+    await sessionStore.redis.del(key);
+};

--- a/src/utils/redisMethods.ts
+++ b/src/utils/redisMethods.ts
@@ -21,7 +21,7 @@ export const getKey = async (key: string): Promise<string | null> => {
     if (!sessionStore) {
         throw new Error("SessionStore is not initialised");
     }
-    return await sessionStore.redis.get(key);
+    return sessionStore.redis.get(key);
 };
 
 export const deleteKey = async (key: string): Promise<void> => {


### PR DESCRIPTION
Resolves [BI-14305](https://companieshouse.atlassian.net/browse/BI-14305) 

**Original PR**
See https://github.com/companieshouse/orders.web.ch.gov.uk/pull/265



**Issue** 
Testing in Staging found the payment reference ended up in some cases being `undefined` - possibly not being set properly  (it was stored in `req.session.extradata`) which caused error page as payment reference/response was be empty due the payments api not being able to be called. 
Bit of background- Payment reference is only able to be retrieved from the `createPayment` function in `basket-controller. `
However, the payment reference is needed to call `getPayment`  (via paymentAPI) in  the order-confirmation controller where the response is validated with the query params to display on the confirmation page. 

Thus, the payment reference needed to be stored/ and be able to survive the redirect from `basket`, to the` payments service` to `order-confirmation controller `
This attempts to use Redis cache to store the reference  against the userid  , instead of storing it in req.session.extradata, which is then extracted from Redis in order-confirmation controller.







[BI-14305]: https://companieshouse.atlassian.net/browse/BI-14305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ